### PR TITLE
Suppress the buttons on the printout for pages cabnaviagtor.php and dc_stats.php

### DIFF
--- a/css/print.css
+++ b/css/print.css
@@ -3,7 +3,7 @@
 body {font-size: 12px;}
 p, h2, h3, h1 { margin-bottom: .25em; margin-top: .25em; }
 
-#header,#sidebar {display: none;}
+#header, #sidebar, .nav, .dcstats .heading > div + div button {display: none;}
 
 div.main {
 	display: block;

--- a/dc_stats.php
+++ b/dc_stats.php
@@ -66,6 +66,7 @@ $(document).ready(function() {
   
   <title>openDCIM Data Center Information Management</title>
   <link rel="stylesheet" href="css/inventory.php" type="text/css">
+  <link rel="stylesheet" href="css/print.css" type="text/css" media="print">
   <link rel="stylesheet" href="css/jquery-ui.css" type="text/css">
   <!--[if lte IE 8]>
     <link rel="stylesheet"  href="css/ie.css" type="text/css">
@@ -94,7 +95,7 @@ echo '<div class="main">
 	<h2>',$config->ParameterArray["OrgName"],'</h2>
 	<h3>',__("Data Center Statistics"),'</h3>
   </div>
-  <div>
+  <div class="nav">
 	<button onclick="loadCanvas()">',__("Overview"),'</button>
 	<button onclick="space()">',__("Space"),'</button>
 	<button onclick="weight()">',__("Weight"),'</button>


### PR DESCRIPTION
The action buttons shouldn't show on a print view of the mentioned pages.
