### PR TITLE
Updates the /cabnavigator.php in two respects, zero rack unit drop, flags appear in legend only if used

### DIFF
--- a/cabnavigator.php
+++ b/cabnavigator.php
@@ -252,6 +252,8 @@ function get_cabinet_owner_color($cabinet, &$deptswithcolor) {
 	<tr><td>".__("Pos")."</td><td>".__("Device")."</td></tr>\n";
 
 	$heighterr="";
+        $ownership_unassigned = false;
+        $template_unassigned = false;
 	while(list($devID,$device)=each($devList)){
 		$devTop=$device->Position + $device->Height - 1;
 		
@@ -269,8 +271,10 @@ function get_cabinet_owner_color($cabinet, &$deptswithcolor) {
 		}
 
 		$highlight="<blink><font color=red>";
-		if($device->TemplateID==0){$highlight.="(T)";}
-		if($device->Owner==0){$highlight.="(O)";}
+		if($device->TemplateID==0){$highlight.="(T)";
+                  $template_unassigned = true;}
+		if($device->Owner==0){$highlight.="(O)";
+                  $ownership_unassigned = true;}
 		$highlight.= "</font></blink>";
 
 		if($device->NominalWatts >0){
@@ -312,7 +316,7 @@ function get_cabinet_owner_color($cabinet, &$deptswithcolor) {
 		}
 		$reserved=($device->Reservation==false)?"":" reserved";
 		if($devTop<$currentHeight){
-			for($i=$currentHeight;$i>$devTop;$i--){
+			for($i=$currentHeight;($i>$devTop)and($i>0);$i--){
 				$errclass=($i>$cab->CabinetHeight)?' class="error"':'';
 				if($errclass!=''){$heighterr="yup";}
 				if($i==$currentHeight){
@@ -392,15 +396,22 @@ function get_cabinet_owner_color($cabinet, &$deptswithcolor) {
 	if($legend!=""){
 //		$legend.='<p><span class="border">&nbsp;&nbsp;&nbsp;&nbsp;</span> - Custom Color Not Assigned</p>';
 	}
+        // add legend for the flags which actually used in the cabinet
+        $legend_flags = '';
+        if ($ownership_unassigned) {
+          $legend_flags.= '		<p><font color=red>(O)</font> - '.__("Owner Unassigned").'</p>';
+        }
+        if ($template_unassigned) {
+          $legend_flags .= '		<p><font color=red>(T)</font> - '.__("Template Unassigned").'</p>';
+        }
+        
 
 $body.='</table>
 </div>
 <div id="infopanel">
 	<fieldset>
-		<legend>'.__("Markup Key").'</legend>
-		<p><font color=red>(O)</font> - '.__("Owner Unassigned").'</p>
-		<p><font color=red>(T)</font> - '.__("Template Unassigned").'</p>
-'.$legend.'
+		<legend>'.__("Markup Key")."</legend>\n".$legend_flags."\n"
+.$legend.'
 	</fieldset>
 	<fieldset>
 		<legend>'.__("Cabinet Metrics").'</legend>


### PR DESCRIPTION
Updates the /cabnavigator.php in two respects, zero rack unit drop, flags appear in legend only if used. 

The first screenshot shows the original behavior. [1] shows all potential flags used for devices in the cabinet view. If a zero height device is present then rack position 0 is shown for a rack as can be seen at [2]. Since zero height devices already appear in the extra box "[Zero-U Devices]" it doesn't make much sense to generate the zero rack unit.
![cabinet_height_fixed_prior2patch_20130617a](https://f.cloud.github.com/assets/2499906/664288/73d0d184-d781-11e2-94b0-bbc9597e5024.png)

The fix can be seen in the following picture. Only the flags which are actually used in the rack view are displayed in the legend, see [1]. Also the zero rack position has been removed from the rack view, see [2].
![cabinet_height_fixed_20130617a](https://f.cloud.github.com/assets/2499906/664295/a50ae69a-d781-11e2-9ff3-3cb13d89cae3.png)
