### PR TITLE
Broken icon shown when mapping cabinet location and DC map is not set.

### DIFF
--- a/mapmaker.php
+++ b/mapmaker.php
@@ -140,11 +140,19 @@ $(document).ready(function() {
     <p class="instructions"><?php echo __("Click and drag on the image to select an area for cabinet"),' ',$cab->Location; ?>.</p> 
  
     <div class="frame" style="margin: 0 0.3em; width: 300px; height: 300px;"> 
-      <?php if (         strlen($dc->DrawingFileName) > 0
-                and     is_file($dc->DrawingFileName) 
-                and is_readable($dc->DrawingFileName) ) { ?>
-          <img id="map" src="<?php echo "drawings/$dc->DrawingFileName"; ?>" /> 
-      <?php } else { ?>
+      <?php 
+        $mapfile = "drawings/$dc->DrawingFileName";
+        if (strlen($mapfile)) {
+            if (is_file($mapfile)) {
+                if (is_readable($mapfile)) {  
+                    echo "<img id=\"map\" src=\"$mapfile\" />";
+                } else {
+                    echo '<p class="warning">Please check the permissions on '.$dc->DrawingFileName.'.</p>';
+                }
+            } else {
+                echo '<p class="warning">Please check that '.$dc->DrawingFileName.' is actually a file.</p>';
+            }
+        } else { ?>
           <p class="warning">Please configure an imagemap for this datacenter before setting coordinates.</p>
           <p class="instructions">(Edit Data Centers&rarr;Data Center&rarr;Drawing URL)</p>
       <?php } ?>


### PR DESCRIPTION
This patch adds some error handling for when data centers have unconfigured maps, and the admin tries to map the cabinet coordinates.
