### PR TITLE
Further formatting correction on the "Markup Key" legend.

### DIFF
--- a/cabnavigator.php
+++ b/cabnavigator.php
@@ -202,10 +202,10 @@ function renderUnassignedTemplateOwnership($device) {
 			.freespace {background-color: {$config->ParameterArray['FreeSpaceColor']};}\n";
 
 		if($config->ParameterArray["ReservedColor"] != "#FFFFFF"){
-			$legend.='<p><span class="reserved colorbox border"></span> - '.__("Reservation").'</p>';
+			$legend.='<div class="legenditem"><span class="reserved colorbox border"></span> - '.__("Reservation").'</div>';
 		}
 		if($config->ParameterArray["FreeSpaceColor"] != "#FFFFFF"){
-			$legend.='<p><span class="freespace color border"></span> - '.__("Free Space").'</p>';
+			$legend.='<div class="legenditem"><span class="freespace color border"></span> - '.__("Free Space").'</div>';
 		}
 	}
 

--- a/css/inventory.php
+++ b/css/inventory.php
@@ -138,7 +138,7 @@ div#imageselection { display: none;}
 .request legend {border: 1px <?php echo $config->ParameterArray['HeaderColor']; ?> solid;background-color: white; padding: .15em;}
 .errmsg {display:block;font-style:italic;margin-left:2em;}
 .hlight {color: red;}
-.legenditem { }
+.legenditem {padding: 0.2em; }
 .colorbox {width: 1em; display: inline-block; height: 1.2em; margin: 0px;
     padding: 0px; }
 }


### PR DESCRIPTION
Sorry for the trouble I am causing by the probably confusing updates. But it should be now all fixed again, see below.

![opendcim_indicator_missing_template_ownership_not_showing_20140218b](https://f.cloud.github.com/assets/2499906/2201267/b2aa1b54-98ec-11e3-95d4-da03b0cbe782.png)
