### PR TITLE
Add FirmwareVersion to CreatePDU() INSERT statement

### DIFF
--- a/power.inc.php
+++ b/power.inc.php
@@ -457,7 +457,7 @@ class PowerDistribution {
 		$sql="INSERT INTO fac_PowerDistribution SET Label=\"$this->Label\", 
 			CabinetID=$this->CabinetID, TemplateID=$this->TemplateID, 
 			IPAddress=\"$this->IPAddress\", SNMPCommunity=\"$this->SNMPCommunity\", 
-			FirmwareVersion=$this->FirmwareVersion, PanelID=$this->PanelID, 
+			FirmwareVersion=\"$this->FirmwareVersion\", PanelID=$this->PanelID, 
 			BreakerSize=$this->BreakerSize, PanelPole=$this->PanelPole, 
 			InputAmperage=$this->InputAmperage, FailSafe=$this->FailSafe, 
 			PanelID2=$this->PanelID2, PanelPole2=$this->PanelPole2;";


### PR DESCRIPTION
When adding a CDU to a rack we received the following error:

CreatePDU::PDO Error: Field 'FirmwareVersion' doesn't have a default value SQL=INSERT INTO fac_PowerDistribution SET Label="PDU1", \n\t\t\tCabinetID=229, TemplateID=2, \n\t\t\tIPAddress="", SNMPCommunity="", \n\t\t\tPanelID=0, BreakerSize=1, \n\t\t\tPanelPole=0, InputAmperage=0, \n\t\t\tFailSafe=0, PanelID2=0, PanelPole2=0;

Added the FirmwareVersion to the INSERT as the database field is marked NOT NULL and should explicitly exist in the query.
