### PR TITLE
getFirstPort needs to handle more port name styles

### DIFF
--- a/assets.inc.php
+++ b/assets.inc.php
@@ -3770,9 +3770,7 @@ class SwitchInfo {
 		foreach( $portList as $index => $port ) {
 			$head = @end( explode( ".", $index ) );
 			$portdesc = @end( explode( ":", $port));
-			if ( preg_match( "/\/[01]$/", $portdesc )) {
-				$x[$head] = $portdesc;
-			} // Find lines that end with /1
+			$x[$head] = $portdesc;
 		}
 		return $x;
 	}


### PR DESCRIPTION
Not all switches export port names with '/' in them (BNT and Cumulus Linux switches are a couple examples). Removing the regex at least gives the user full visibility to choose the first port. perhaps the regex could be made a configurable option at some point.
