### PR TITLE
Incorporate more matches into findFirstPort

### DIFF
--- a/assets.inc.php
+++ b/assets.inc.php
@@ -3770,7 +3770,7 @@ class SwitchInfo {
 		foreach( $portList as $index => $port ) {
 			$head = @end( explode( ".", $index ) );
 			$portdesc = @end( explode( ":", $port));
-			if ( preg_match( "/\/[01]$/", $portdesc )) {
+			if ( preg_match( "/(bond|swp|eth|Ethernet|Port-Channel|\/)[01]$/", $portdesc )) {
 				$x[$head] = $portdesc;
 			} // Find lines that end with /1
 		}


### PR DESCRIPTION
Port-Channel, swp, eth, Ethernet, and bond devices can show up in some vendors' snmp output. We should match on those as well.
