### PR TITLE
list children in cabaudit.php

### DIFF
--- a/cabaudit.php
+++ b/cabaudit.php
@@ -453,6 +453,31 @@ class PDF_Diag extends PDF_Sector {
 			$mfg->GetManufacturerByID();
 			$pdf->Cell( $cellWidths[9], 6, $mfg->Name." ".$templ->Model, 'LBRT', 1, 'L', $fill );
 
+			if ( $devRow->DeviceType == "Chassis" ) {
+				$chDev = new Device();
+				$chDev->DeviceID = $devRow->DeviceID;
+				$chList = $chDev->GetDeviceChildren();
+
+				foreach ( $chList as $chRow ) {
+
+					$pdf->Cell( $cellWidths[0], 6, $chRow->Label, 'LBRT', 0, 'R', $fill );
+					$pdf->Cell( $cellWidths[1], 6, $chRow->SerialNo, 'LBRT', 0, 'L', $fill );
+					$pdf->Cell( $cellWidths[2], 6, $chRow->AssetTag, 'LBRT', 0, 'L', $fill );
+					$pdf->Cell( $cellWidths[3], 6, $chRow->Position, 'LBRT', 0, 'L', $fill );
+					$pdf->Cell( $cellWidths[4], 6, $chRow->Height, 'LBRT', 0, 'L', $fill );
+					$pdf->Cell( $cellWidths[5], 6, $chRow->Ports, 'LBRT', 0, 'L', $fill );
+					$pdf->Cell( $cellWidths[6], 6, '', 'LBRT', 0, 'L', $fill );
+					$pdf->Cell( $cellWidths[7], 6, 'Parent', 'LBRT', 0, 'L', $fill );
+					$pdf->Cell( $cellWidths[8], 6, 'Parent', 'LBRT', 0, 'L', $fill );
+					$templ->TemplateID=$chRow->TemplateID;
+					$templ->GetTemplateByID();
+					$mfg->ManufacturerID=$templ->ManufacturerID;
+					$mfg->GetManufacturerByID();
+					$pdf->Cell( $cellWidths[9], 6, $mfg->Name." ".$templ->Model, 'LBRT', 1, 'L', $fill );
+
+					$fill =! $fill;
+				}
+			}
 			
 			$pdf->Cell( $cellWidths[0], 6, '', 'LBRT', 0, 'L', $fill );
 			$pdf->Cell( $cellWidths[1], 6, '', 'LBRT', 0, 'L', $fill );


### PR DESCRIPTION
Added list of children of chassis devices to cabinet audit report.

Not sure if there was any reason this isn't already included, or if this has been discussed in the past.
Have this change working on my 3.2.1 installation.
