### PR TITLE
Reducing memory usage of report_network_map

### DIFF
--- a/report_network_map.php
+++ b/report_network_map.php
@@ -2,7 +2,7 @@
     require_once "db.inc.php";
     require_once "facilities.inc.php";
 
-	  $subheader=__("Network Map Viewer");
+    $subheader=__("Network Map Viewer");
 
     $dotCommand = $config->ParameterArray["dot"];
     # if format is set, graph options should be set and ready to be rendered


### PR DESCRIPTION
This first pass at reducing memory usage drops reported usage by about
25% (251 devices with 400 connections between them use 2.8M vs 3.6M
before)
