### PR TITLE
The "Temperature Units" for a sensor template is incorrectly read out fr...

### DIFF
--- a/sensor_templates.php
+++ b/sensor_templates.php
@@ -156,7 +156,7 @@ echo '   </select>
 
 	$unitofmeasurev = array( "english", "metric" );
 	foreach ( $unitofmeasurev as $unit ) {
-		$selected = ( $unit == $template->UnitOfMeasure ) ? 'selected':'';
+		$selected = ( $unit == $template->mUnits ) ? 'selected':'';
 		print "\t\t<option value=\"$unit\" $selected>$unit</option>\n";
 	}
 	


### PR DESCRIPTION
...om a database.

Small correction: without it "Temperature Units" for a sensor template is incorrectly read out from a database.