### PR TITLE
Replace MS licensed fonts to another free license fonts.

### DIFF
--- a/loadfonts.php
+++ b/loadfonts.php
@@ -3,27 +3,45 @@
 Place corresponding php-files of fonts in the font directory */
 
   // For example, set of cyrillic (cp1251) TrueType fonts
-	/* ArialMT
-	$pdf->AddFont('ArialMT','','arial.php');
-	$pdf->AddFont('ArialMT','B','arialbd.php');
-	$pdf->AddFont('ArialMT','I','ariali.php');
-	$pdf->AddFont('ArialMT','BI','arialbi.php'); */
-	
-	/* CourierNew
-	$pdf->AddFont('CourierNew','','cour.php');
-	$pdf->AddFont('CourierNew','B','courbd.php');
-	$pdf->AddFont('CourierNew','I','couri.php');
-	$pdf->AddFont('CourierNew','BI','courbi.php'); */
-	
 	/* DejaVuSans
 	$pdf->AddFont('DejaVuSans','','DejaVuSans.php');
 	$pdf->AddFont('DejaVuSans','B','DejaVuSans-Bold.php');
-	$pdf->AddFont('DejaVuSans','I','DejaVuSans-BoldOblique.php');
+	$pdf->AddFont('DejaVuSans','I','DejaVuSans-Oblique.php');
 	$pdf->AddFont('DejaVuSans','BI','DejaVuSans-BoldOblique.php'); */
-	
-	/* SegoeCondensed
-	$pdf->AddFont('SegoeCondensed','','segoe.php');
-	$pdf->AddFont('SegoeCondensed','B','segoeb.php');
-	$pdf->AddFont('SegoeCondensed','I','segoe.php');
-	$pdf->AddFont('SegoeCondensed','BI','segoeb.php'); */
+
+	/* DejaVuSansCondensed
+	$pdf->AddFont('DejaVuSansCondensed','','DejaVuSansCondensed.php');
+	$pdf->AddFont('DejaVuSansCondensed','B','DejaVuSansCondensed-Bold.php');
+	$pdf->AddFont('DejaVuSansCondensed','I','DejaVuSansCondensed-Oblique.php');
+	$pdf->AddFont('DejaVuSansCondensed','BI','DejaVuSansCondensed-BoldOblique.php'); */
+
+	/* DejaVuSansMono
+	$pdf->AddFont('DejaVuSansMono','','DejaVuSansMono.php');
+	$pdf->AddFont('DejaVuSansMono','B','DejaVuSansMono-Bold.php');
+	$pdf->AddFont('DejaVuSansMono','I','DejaVuSansMono-Oblique.php');
+	$pdf->AddFont('DejaVuSansMono','BI','DejaVuSansMono-BoldOblique.php'); */
+
+	/* DejaVuSerif
+	$pdf->AddFont('DejaVuSerif','','DejaVuSerif.php');
+	$pdf->AddFont('DejaVuSerif','B','DejaVuSerif-Bold.php');
+	$pdf->AddFont('DejaVuSerif','I','DejaVuSerif-Italic.php');
+	$pdf->AddFont('DejaVuSerif','BI','DejaVuSerif-BoldItalic.php'); */
+
+	/* DejaVuSerifCondensed
+	$pdf->AddFont('DejaVuSerifCondensed','','DejaVuSerifCondensed.php');
+	$pdf->AddFont('DejaVuSerifCondensed','B','DejaVuSerifCondensed-Bold.php');
+	$pdf->AddFont('DejaVuSerifCondensed','I','DejaVuSerifCondensed-Italic.php');
+	$pdf->AddFont('DejaVuSerifCondensed','BI','DejaVuSerifCondensed-BoldItalic.php'); */
+
+	/* OpenSans-Bold
+	$pdf->AddFont('OpenSans-Bold','','OpenSans-Bold.php');
+	$pdf->AddFont('OpenSans-Bold','B','OpenSans-ExtraBold.php');
+	$pdf->AddFont('OpenSans-Bold','I','OpenSans-BoldItalic.php');
+	$pdf->AddFont('OpenSans-Bold','BI','OpenSans-ExtraBoldItalic.php'); */
+
+	/* OpenSans-Cond */
+	$pdf->AddFont('OpenSans-Cond','','OpenSans-CondLight.php');
+	$pdf->AddFont('OpenSans-Cond','B','OpenSans-CondBold.php');
+	$pdf->AddFont('OpenSans-Cond','I','OpenSans-CondLightItalic.php');
+	$pdf->AddFont('OpenSans-Cond','BI','OpenSans-CondBold.php');
 ?>


### PR DESCRIPTION
Replace MS licensed fonts to another free license fonts. For example, DejaVu family fonts is under free Bitstream Vera Fonts license and OpenSans family fonts is under free Apache Licence 2.0.