### PR TITLE
Additional multiplier for phases OIDs...

### DIFF
--- a/cdu_templates.php
+++ b/cdu_templates.php
@@ -141,7 +141,7 @@ echo '</select>
    <div><label for="multiplier">',__("Multiplier"),'</label></div>
    <div><select name="multiplier" id="multiplier">';
    
-	$Multi=array("0.1", "1","10","100");
+	$Multi=array("0.01","0.1","1","10","100");
         $mult = 1;
 
         // Loop to find the template default multiplier, if any


### PR DESCRIPTION
Additional multiplier for phases OIDs: it is necessary for creation of CDU template of the "APC Modular Remote Power Panel, 277kVA, 400A, 400V, 72 Pole, 300mm (PDPM277H)".