### PR TITLE
Additional multiplier for phases OIDs...

### DIFF
--- a/power.inc.php
+++ b/power.inc.php
@@ -43,7 +43,7 @@ class CDUTemplate {
 
 	function MakeSafe(){
 		$validSNMPVersions=array(1,'2c');
-		$validMultipliers=array(0.1,1,10,100);
+		$validMultipliers=array(0.01,0.1,1,10,100);
 		$validProcessingProfiles=array('SingleOIDWatts','SingleOIDAmperes',
 			'Combine3OIDWatts','Combine3OIDAmperes','Convert3PhAmperes');
 


### PR DESCRIPTION
Additional multiplier for phases OIDs: it is necessary for creation of CDU template of the "APC Modular Remote Power Panel, 277kVA, 400A, 400V, 72 Pole, 300mm (PDPM277H)".