### PR TITLE
APC PDPM277H: the wrong calculation of total 3ph power for the module…

### DIFF
--- a/power.inc.php
+++ b/power.inc.php
@@ -1067,6 +1067,9 @@ class PowerDistribution {
 			if($row["OID2"]!="" && $row["OID3"]!=""){
 				$pollValue2=floatval(self::OSS_SNMP_Lookup($dev,null,$row["OID2"]));
 				$pollValue3=floatval(self::OSS_SNMP_Lookup($dev,null,$row["OID3"]));
+				// Negativity test, it is required for APC 3ph modular PDU with IEC309-5W wires
+				if ($pollValue2<0) $pollValue2=0;
+				if ($pollValue3<0) $pollValue3=0;
 			}
 			
 			// Have to reset this every time, otherwise the exec() will append


### PR DESCRIPTION
… with IEC309-5W wires

If the module with IEC309-5W wires is inserted into the modular PDU APC PDPM277H, total 3ph power is calculated incorrectly as OID2 and OID3 thus are equal "-1". For example, snmpwalk for total 3ph power:

# snmpwalk -v2c -cpublic 192.168.0.16 .1.3.6.1.4.1.318.1.1.22.2.6.1.20
SNMPv2-SMI::enterprises.318.1.1.22.2.6.1.20.1.1 = INTEGER: 17 <-- total 3ph power is 1.7kW for module #1 with IEC309-5W
SNMPv2-SMI::enterprises.318.1.1.22.2.6.1.20.1.2 = INTEGER: -1 <-- we need ignore this value for module #1 with IEC309-5W
SNMPv2-SMI::enterprises.318.1.1.22.2.6.1.20.1.3 = INTEGER: -1 <-- we need ignore this value for module #1 with IEC309-5W

SNMPv2-SMI::enterprises.318.1.1.22.2.6.1.20.2.1 = INTEGER: 9 <-- total 3ph power is 0.9kW for module #2 with IEC309-5W
SNMPv2-SMI::enterprises.318.1.1.22.2.6.1.20.2.2 = INTEGER: -1 <-- we need ignore this value for module #2 with IEC309-5W
SNMPv2-SMI::enterprises.318.1.1.22.2.6.1.20.2.3 = INTEGER: -1 <-- we need ignore this value for module #2 with IEC309-5W

SNMPv2-SMI::enterprises.318.1.1.22.2.6.1.20.9.1 = INTEGER: 2 <-- phase L1 power is 0.2kW for module #9 with IEC309-3W
SNMPv2-SMI::enterprises.318.1.1.22.2.6.1.20.9.2 = INTEGER: 8 <-- phase L2 power is 0.8kW for module #9 with IEC309-3W
SNMPv2-SMI::enterprises.318.1.1.22.2.6.1.20.9.3 = INTEGER: 2 <-- phase L3 power is 0.2kW for module #9 with IEC309-3W

Apparently above, for the module #1 total 3ph power was calculated as 17-1-1=15 (1.5kW) that is wrong. As for IEC309-5W wires modules full capacity has to be calculated, for example, as 17+0+0=17 (1.7kW), and for IEC309-3W wires modules, for example, as 2+8+2=12 (1.2kW).