### PR TITLE
Bugfix: NumOutlets in CDUTemplate it isn't filled?..

### DIFF
--- a/device_templates.php
+++ b/device_templates.php
@@ -224,6 +224,7 @@
 			$cdutemplate->ProcessingProfile=$_POST['ProcessingProfile'];
 			$cdutemplate->Voltage=$_POST["Voltage"];
 			$cdutemplate->Amperage=$_POST["Amperage"];
+			$cdutemplate->NumOutlets=$template->PSCount;
 			$status=($cdutemplate->UpdateTemplate())?$status:__('Error updating cdu attributes');
 
 			return $status;


### PR DESCRIPTION
Bugfix: NumOutlets in CDUTemplate it isn't filled when create/update template.
Because of it in CDU tooltips it isn't correct displayed used and total power connection.