### PR TITLE
Add a constructor to class DataCenter.

### DIFF
--- a/infrastructure.inc.php
+++ b/infrastructure.inc.php
@@ -215,8 +215,7 @@ class DataCenter {
 
 	public function __construct($dcid=false){
 		if($dcid){
-			$this->DataCenterID=$dcid;
-			$this->GetDataCenter();
+			$this->DataCenterID=intval($dcid);
 		}
 		return $this;
 	}

--- a/infrastructure.inc.php
+++ b/infrastructure.inc.php
@@ -213,6 +213,14 @@ class DataCenter {
 		$this->DrawingFileName=stripslashes($this->DrawingFileName);
 	}
 
+	public function __construct($dcid=false){
+		if($dcid){
+			$this->DataCenterID=$dcid;
+			$this->GetDataCenter();
+		}
+		return $this;
+	}
+
 	static function RowToObject($row){
 		$dc=New DataCenter();
 		$dc->DataCenterID=$row["DataCenterID"];


### PR DESCRIPTION
The class constructor is missing from class DataCenter.
With this constructor, we can instantiate a DataCenter object with it DataCenterID and populating it at call.