### PR TITLE
New data type of CustomValues - selectbox

### DIFF
--- a/assets.inc.php
+++ b/assets.inc.php
@@ -5041,7 +5041,7 @@ class DeviceCustomAttribute {
 	var $DefaultValue;
 
 	function MakeSafe() {
-		$validtypes=array("string","number","integer","date","phone","email","ipv4","url","checkbox");
+		$validtypes=array("string","number","integer","date","phone","email","ipv4","url","checkbox","set");
 
 		$this->AttributeID=intval($this->AttributeID);
 		$this->Label=sanitize($this->Label);
@@ -5237,7 +5237,7 @@ class DeviceCustomAttribute {
 	}
 
 	static function GetDeviceCustomAttributeTypeList() {
-		$validtypes=array("string","number","integer","date","phone","email","ipv4","url","checkbox");
+		$validtypes=array("string","number","integer","date","phone","email","ipv4","url","checkbox","set");
 
 		return $validtypes;
 	}	

--- a/device_templates.php
+++ b/device_templates.php
@@ -765,7 +765,7 @@ foreach($dcaList as $dca) {
 	} else if ($dca->AttributeType=="set") {
 		$dcaValues = explode(',',$dca->DefaultValue);
 		$selected = "";
-		echo '<select name="tdca[',$dca->AttributeID,'][value]"',$validation,' id="tdca[',$dca->AttributeID,'][value]">';
+		echo '<select name="tdca[',$dca->AttributeID,'][value]" id="tdca[',$dca->AttributeID,'][value]">';
 		foreach($dcaValues as $dcaValue){
 			$selected = "";
 			if(strcmp($templatedcaValue, $dcaValue)==0){

--- a/device_templates.php
+++ b/device_templates.php
@@ -801,7 +801,7 @@ foreach($dcaList as $dca) {
 				var type = $("#"+typeid).val();
 				if(this.checked){
 					$("#"+inputid).removeClass();
-					if(type!="checkbox" && type!="string"){
+					if(type!="checkbox" && type!="string" && type!="set"){
 						$("#"+inputid).addClass("validate[custom["+type+"]]");
 					}
 				} else {

--- a/device_templates.php
+++ b/device_templates.php
@@ -762,6 +762,18 @@ foreach($dcaList as $dca) {
 			$checked=" checked";
 		}
 		echo __("Default:").' <input type="checkbox" name="tdca[',$dca->AttributeID,'][value]" ',$checked,'>';
+	} else if ($dca->AttributeType=="set") {
+		$dcaValues = explode(',',$dca->DefaultValue);
+		$selected = "";
+		echo '<select name="tdca[',$dca->AttributeID,'][value]"',$validation,' id="tdca[',$dca->AttributeID,'][value]">';
+		foreach($dcaValues as $dcaValue){
+			$selected = "";
+			if(strcmp($templatedcaValue, $dcaValue)==0){
+				$selected=" selected";
+			}
+			echo '<option',$selected,' value="',$dcaValue,'">',$dcaValue,'</option>';
+		}
+		echo '</select>';
 	} else {
 		$validation="";
 		if($templatedcaChecked != "" && $dca->AttributeType!="string" && $dca->AttributeType!="checked") {

--- a/devices.php
+++ b/devices.php
@@ -898,7 +898,7 @@
 				}
 				echo '<div><input type="checkbox" name="',$inputname,'" id="',$inputname,'"',$checked,'></div>';
 			} else if ($cvtype=="set") {
-				$dcaValues = explode(',',$dca->DefaultValue);
+				$dcaValues = explode(',',$dcaList[$customkey]->DefaultValue);
 				$selected = "";
 				echo '<div><select name="',$inputname,'" id="',$inputname,'">';
 				foreach($dcaValues as $dcaValue){

--- a/devices.php
+++ b/devices.php
@@ -897,6 +897,18 @@
 					$checked = " checked";
 				}
 				echo '<div><input type="checkbox" name="',$inputname,'" id="',$inputname,'"',$checked,'></div>';
+			} else if ($cvtype=="set") {
+				$dcaValues = explode(',',$dca->DefaultValue);
+				$selected = "";
+				echo '<div><select name="',$inputname,'" id="',$inputname,'">';
+				foreach($dcaValues as $dcaValue){
+					$selected = "";
+					if(strcmp($customdata["value"], $dcaValue)==0){
+						$selected=" selected";
+					}
+					echo '<option',$selected,' value="',$dcaValue,'">',$dcaValue,'</option>';
+				}
+				echo '</select></div>';
 			} else {
 				echo '<div><input type="text"',$validation,' name="',$inputname,'" id="',$inputname,'" value="',$customdata["value"],'"></div>';
 


### PR DESCRIPTION
#630 
Options are stored as comma separated values. The first option is interpreted as the default value.
For example:
1. The default value is empty.
![1_1](https://cloud.githubusercontent.com/assets/7326529/11360225/9dcd6fc2-9293-11e5-889f-cab707f07cfc.PNG)

![1_2](https://cloud.githubusercontent.com/assets/7326529/11360310/67198bcc-9294-11e5-9fb2-472e0d4e34fe.png)


2. The default value is not empty.
![2_1](https://cloud.githubusercontent.com/assets/7326529/11360240/c0d33f2e-9293-11e5-8989-9bbee7e4ff37.PNG)

![2_2](https://cloud.githubusercontent.com/assets/7326529/11360313/6d6f5bc8-9294-11e5-8134-fe2b89647887.png)
