### PR TITLE
Fixes for OAuth authentication bugs

### DIFF
--- a/db.inc.php-dist
+++ b/db.inc.php-dist
@@ -22,13 +22,13 @@
 	
 	if ( !defined( "AUTHENTICATION") ) {
 		define( "AUTHENTICATION", "Apache" );
+	    /* If you want to use Oauth authentication, uncomment the next 2 lines
+	       and place your authentication handler in login.php (create symbolic link). 
+	       ex.  cp oauth/login_with_google.php oauth/login.php
+	    */
+	    // define( "AUTHENTICATION", "Oauth" );
+	    // session_start();
 	}
-	/* If you want to use Oauth authentication, uncomment the next 2 lines
-	   and place your authentication handler in login.php (create symbolic link). 
-	   ex.  cp oauth/login_with_google.php oauth/login.php
-	*/
-	// define( "AUTHENTICATION", "Oauth" );
-	// session_start();
 	
 	require_once( 'config.inc.php');
 	$config=new Config();

--- a/poll_esx_inventory.php
+++ b/poll_esx_inventory.php
@@ -1,4 +1,5 @@
 <?php
+  define( 'AUTHENTICATION', 'Apache' );
   require_once('db.inc.php');
   require_once('facilities.inc.php');
   

--- a/poll_pdu_stats-multiprocess.php
+++ b/poll_pdu_stats-multiprocess.php
@@ -5,6 +5,7 @@
 	Not truly multi-threaded, as that requires the PECL pthreads extension, which in turns requires manual
 	compilation.  Instead, we will use multi-processing techniques and the pcntl_ set of intrinsic PHP functions.
 	 */
+	define( 'AUTHENTICATION', 'Apache' );
 	DEFINE("MAXPROCESS", 10);
 
 	require_once("db.inc.php");

--- a/poll_pdu_stats.php
+++ b/poll_pdu_stats.php
@@ -1,4 +1,5 @@
 <?php
+  define( 'AUTHENTICATION', 'Apache' );
   require( 'db.inc.php' );
   require( 'facilities.inc.php' );
   

--- a/poll_temperature_sensors.php
+++ b/poll_temperature_sensors.php
@@ -1,4 +1,5 @@
 <?php
+	define( "AUTHENTICATION", "Apache");
 	require("db.inc.php");
 	require("facilities.inc.php");
 	


### PR DESCRIPTION
When OAuth is enabled, the latest versions of the polling code bails out due to the inability to call session_start(). AUTHENTICATION needs to be Apache for such calls, as auth doesn't, and shouldn't, matter for cli access.