### PR TITLE
Adding no-cache meta tags and 2 new Device types

### DIFF
--- a/assets.inc.php
+++ b/assets.inc.php
@@ -1245,7 +1245,7 @@ class Device {
 		global $config;
 
 		//Keep weird values out of DeviceType
-		$validdevicetypes=array('Server','Appliance','Storage Array','Switch','Chassis','Patch Panel','Physical Infrastructure','CDU','Sensor');
+		$validdevicetypes=array('Server','Appliance','Storage Array','Switch','Chassis','Patch Panel','Physical Infrastructure','CDU','Sensor','WiFi AP','Router');
 		$validSNMPVersions=array(1,'2c',3);
 		$validv3SecurityLevels=array('noAuthNoPriv','authNoPriv','authPriv');
 		$validv3AuthProtocols=array('MD5','SHA');
@@ -4353,7 +4353,7 @@ class RackRequest {
 	// Create MakeSafe / MakeDisplay functions
 	function MakeSafe(){
 		//Keep weird values out of DeviceType
-		$validdevicetypes=array('Server','Appliance','Storage Array','Switch','Chassis','Patch Panel','Physical Infrastructure','CDU');
+		$validdevicetypes=array('Server','Appliance','Storage Array','Switch','Chassis','Patch Panel','Physical Infrastructure','CDU','WiFi AP','Router');
 
 		$this->RequestID=intval($this->RequestID);
 		$this->RequestorID=intval($this->RequestorID);

--- a/cabinets.php
+++ b/cabinets.php
@@ -122,6 +122,9 @@
 <head>
   <meta http-equiv="X-UA-Compatible" content="IE=Edge">
   <meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
+  <meta http-equiv="CACHE-CONTROL" content="NO-CACHE">
+  <meta http-equiv="EXPIRES" content="Mon, 01 Jan 1997 01:00:00 GMT">
+  <meta http-equiv="PRAGMA" content="NO-CACHE">
   
   <title>Facilities Cabinet Maintenance</title>
   <link rel="stylesheet" href="css/inventory.php" type="text/css">

--- a/cabnavigator.php
+++ b/cabnavigator.php
@@ -424,6 +424,9 @@ $body.='<div id="infopanel">
 <head>
   <meta http-equiv="X-UA-Compatible" content="IE=Edge">
   <meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
+  <meta http-equiv="CACHE-CONTROL" content="NO-CACHE">
+  <meta http-equiv="EXPIRES" content="Mon, 01 Jan 1997 01:00:00 GMT">
+  <meta http-equiv="PRAGMA" content="NO-CACHE">
 
   <title><?php echo $title; ?></title>
   <link rel="stylesheet" href="css/inventory.php" type="text/css">

--- a/cabrow.php
+++ b/cabrow.php
@@ -55,6 +55,9 @@
 <head>
   <meta http-equiv="X-UA-Compatible" content="IE=Edge">
   <meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
+  <meta http-equiv="CACHE-CONTROL" content="NO-CACHE">
+  <meta http-equiv="EXPIRES" content="Mon, 01 Jan 1997 01:00:00 GMT">
+  <meta http-equiv="PRAGMA" content="NO-CACHE">
   
   <title>openDCIM Rows of Cabinets</title>
 

--- a/cdu_templates.php
+++ b/cdu_templates.php
@@ -56,6 +56,9 @@
 <head>
   <meta http-equiv="X-UA-Compatible" content="IE=Edge">
   <meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
+  <meta http-equiv="CACHE-CONTROL" content="NO-CACHE">
+  <meta http-equiv="EXPIRES" content="Mon, 01 Jan 1997 01:00:00 GMT">
+  <meta http-equiv="PRAGMA" content="NO-CACHE">
   
   <title>openDCIM Cabinet Distribution Unit Templates</title>
   <link rel="stylesheet" href="css/inventory.php" type="text/css">

--- a/configuration.php
+++ b/configuration.php
@@ -384,6 +384,9 @@
 <head>
   <meta http-equiv="X-UA-Compatible" content="IE=Edge">
   <meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
+  <meta http-equiv="CACHE-CONTROL" content="NO-CACHE">
+  <meta http-equiv="EXPIRES" content="Mon, 01 Jan 1997 01:00:00 GMT">
+  <meta http-equiv="PRAGMA" content="NO-CACHE">
   
   <title>openDCIM Data Center Inventory</title>
   <link rel="stylesheet" href="css/inventory.php" type="text/css">

--- a/conflicts.php
+++ b/conflicts.php
@@ -691,6 +691,9 @@ class SwitchConnection {
 <head>
   <meta http-equiv="X-UA-Compatible" content="IE=Edge">
   <meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
+  <meta http-equiv="CACHE-CONTROL" content="NO-CACHE">
+  <meta http-equiv="EXPIRES" content="Mon, 01 Jan 1997 01:00:00 GMT">
+  <meta http-equiv="PRAGMA" content="NO-CACHE">
   
   <title>openDCIM Data Center Inventory</title>
   <link rel="stylesheet" href="css/inventory.php" type="text/css">

--- a/contactpopup.php
+++ b/contactpopup.php
@@ -30,6 +30,9 @@
 <head>
   <meta http-equiv="X-UA-Compatible" content="IE=Edge">
   <meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
+  <meta http-equiv="CACHE-CONTROL" content="NO-CACHE">
+  <meta http-equiv="EXPIRES" content="Mon, 01 Jan 1997 01:00:00 GMT">
+  <meta http-equiv="PRAGMA" content="NO-CACHE">
   
   <title>openDCIM Device Maintenance</title>
   <link rel="stylesheet" href="css/inventory.php" type="text/css">

--- a/container.php
+++ b/container.php
@@ -77,6 +77,9 @@
 <head>
   <meta http-equiv="X-UA-Compatible" content="IE=Edge">
   <meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
+  <meta http-equiv="CACHE-CONTROL" content="NO-CACHE">
+  <meta http-equiv="EXPIRES" content="Mon, 01 Jan 1997 01:00:00 GMT">
+  <meta http-equiv="PRAGMA" content="NO-CACHE">
   <title>openDCIM Data Center Inventory</title>
   
   <link rel="stylesheet" href="css/inventory.php" type="text/css">

--- a/container_stats.php
+++ b/container_stats.php
@@ -22,6 +22,9 @@
 <head>
   <meta http-equiv="X-UA-Compatible" content="IE=Edge">
   <meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
+  <meta http-equiv="CACHE-CONTROL" content="NO-CACHE">
+  <meta http-equiv="EXPIRES" content="Mon, 01 Jan 1997 01:00:00 GMT">
+  <meta http-equiv="PRAGMA" content="NO-CACHE">
   
   <title>openDCIM Data Center Information Management</title>
   <link rel="stylesheet" href="css/inventory.php" type="text/css">

--- a/datacenter.php
+++ b/datacenter.php
@@ -97,6 +97,9 @@
 <head>
   <meta http-equiv="X-UA-Compatible" content="IE=Edge">
   <meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
+  <meta http-equiv="CACHE-CONTROL" content="NO-CACHE">
+  <meta http-equiv="EXPIRES" content="Mon, 01 Jan 1997 01:00:00 GMT">
+  <meta http-equiv="PRAGMA" content="NO-CACHE">
   <title>openDCIM Data Center Inventory</title>
   
   <link rel="stylesheet" href="css/inventory.php" type="text/css">

--- a/dc_dashboard.php
+++ b/dc_dashboard.php
@@ -50,6 +50,9 @@
 <head>
   <meta http-equiv="X-UA-Compatible" content="IE=Edge">
   <meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
+  <meta http-equiv="CACHE-CONTROL" content="NO-CACHE">
+  <meta http-equiv="EXPIRES" content="Mon, 01 Jan 1997 01:00:00 GMT">
+  <meta http-equiv="PRAGMA" content="NO-CACHE">
   
   <title>openDCIM Data Center Information Management</title>
   <link rel="stylesheet" href="css/inventory.php" type="text/css">

--- a/dc_stats.php
+++ b/dc_stats.php
@@ -123,6 +123,9 @@ $(document).ready(function() {
 <head>
   <meta http-equiv="X-UA-Compatible" content="IE=Edge">
   <meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
+  <meta http-equiv="CACHE-CONTROL" content="NO-CACHE">
+  <meta http-equiv="EXPIRES" content="Mon, 01 Jan 1997 01:00:00 GMT">
+  <meta http-equiv="PRAGMA" content="NO-CACHE">
   
   <title><?php echo __("openDCIM Data Center Information Management");?></title>
   <link rel="stylesheet" href="css/inventory.php" type="text/css">

--- a/departments.php
+++ b/departments.php
@@ -77,6 +77,9 @@
 <head>
   <meta http-equiv="X-UA-Compatible" content="IE=Edge">
   <meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
+  <meta http-equiv="CACHE-CONTROL" content="NO-CACHE">
+  <meta http-equiv="EXPIRES" content="Mon, 01 Jan 1997 01:00:00 GMT">
+  <meta http-equiv="PRAGMA" content="NO-CACHE">
   
   <title>openDCIM Department Information</title>
   <link rel="stylesheet" href="css/inventory.php" type="text/css">

--- a/dept_groups.php
+++ b/dept_groups.php
@@ -42,6 +42,9 @@
 <head>
   <meta http-equiv="X-UA-Compatible" content="IE=Edge">
   <meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
+  <meta http-equiv="CACHE-CONTROL" content="NO-CACHE">
+  <meta http-equiv="EXPIRES" content="Mon, 01 Jan 1997 01:00:00 GMT">
+  <meta http-equiv="PRAGMA" content="NO-CACHE">
   
   <title><?php __("openDCIM Department Contact Maintenance"); ?></title>
   <link rel="stylesheet" href="css/inventory.php" type="text/css">

--- a/device_manufacturers.php
+++ b/device_manufacturers.php
@@ -69,6 +69,9 @@
 <head>
   <meta http-equiv="X-UA-Compatible" content="IE=Edge">
   <meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
+  <meta http-equiv="CACHE-CONTROL" content="NO-CACHE">
+  <meta http-equiv="EXPIRES" content="Mon, 01 Jan 1997 01:00:00 GMT">
+  <meta http-equiv="PRAGMA" content="NO-CACHE">
   
   <title>openDCIM Device Class Templates</title>
   <link rel="stylesheet" href="css/inventory.php" type="text/css">

--- a/device_templates.php
+++ b/device_templates.php
@@ -329,6 +329,9 @@
 <head>
   <meta http-equiv="X-UA-Compatible" content="IE=Edge">
   <meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
+  <meta http-equiv="CACHE-CONTROL" content="NO-CACHE">
+  <meta http-equiv="EXPIRES" content="Mon, 01 Jan 1997 01:00:00 GMT">
+  <meta http-equiv="PRAGMA" content="NO-CACHE">
   
   <title>openDCIM Device Class Templates</title>
   <link rel="stylesheet" href="css/inventory.php" type="text/css">
@@ -673,7 +676,7 @@ echo '    </select>
    <div><label for="DeviceType">',__("Device Type"),'</label></div>
    <div><select name="DeviceType" id="DeviceType">';
 
-	foreach(array('Server','Appliance','Storage Array','Switch','Chassis','Patch Panel','Physical Infrastructure','CDU','Sensor') as $DevType){
+	foreach(array('Server','Appliance','Storage Array','Switch','Chassis','Patch Panel','Physical Infrastructure','CDU','Sensor','WiFi AP','Router') as $DevType){
 		if($DevType==$template->DeviceType){$selected=" selected";}else{$selected="";}
 		print "		<option value=\"$DevType\"$selected>$DevType</option>\n";
 	}

--- a/devices.php
+++ b/devices.php
@@ -967,6 +967,9 @@ $write=($dev->Rights=="Write")?true:$write;
 <head>
   <meta http-equiv="X-UA-Compatible" content="IE=Edge">
   <meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
+  <meta http-equiv="CACHE-CONTROL" content="NO-CACHE">
+  <meta http-equiv="EXPIRES" content="Mon, 01 Jan 1997 01:00:00 GMT">
+  <meta http-equiv="PRAGMA" content="NO-CACHE">
 
   <title><?php echo $title; ?></title>
   <link rel="stylesheet" href="css/inventory.php" type="text/css">

--- a/escalations.php
+++ b/escalations.php
@@ -43,6 +43,9 @@
 <head>
   <meta http-equiv="X-UA-Compatible" content="IE=Edge">
   <meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
+  <meta http-equiv="CACHE-CONTROL" content="NO-CACHE">
+  <meta http-equiv="EXPIRES" content="Mon, 01 Jan 1997 01:00:00 GMT">
+  <meta http-equiv="PRAGMA" content="NO-CACHE">
   <title>openDCIM Data Center Inventory</title>
   
   <link rel="stylesheet" href="css/inventory.php" type="text/css">

--- a/image_management.php
+++ b/image_management.php
@@ -32,6 +32,9 @@
 <head>
   <meta http-equiv="X-UA-Compatible" content="IE=Edge">
   <meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
+  <meta http-equiv="CACHE-CONTROL" content="NO-CACHE">
+  <meta http-equiv="EXPIRES" content="Mon, 01 Jan 1997 01:00:00 GMT">
+  <meta http-equiv="PRAGMA" content="NO-CACHE">
   
   <title><?php echo __("openDCIM Data Center Inventory");?></title>
   <link rel="stylesheet" href="css/inventory.php" type="text/css">

--- a/infrastructure.inc.php
+++ b/infrastructure.inc.php
@@ -785,7 +785,7 @@ class DeviceTemplate {
 	}
 
 	function MakeSafe(){
-		$validDeviceTypes=array('Server','Appliance','Storage Array','Switch','Chassis','Patch Panel','Physical Infrastructure','CDU','Sensor');
+		$validDeviceTypes=array('Server','Appliance','Storage Array','Switch','Chassis','Patch Panel','Physical Infrastructure','CDU','Sensor','WiFi AP','Router');
 		$validSNMPVersions=array(1,'2c',3);
 
 		// Instead of defaulting to v2c for snmp we'll default to whatever the system default is

--- a/mapmaker.php
+++ b/mapmaker.php
@@ -51,6 +51,9 @@
 <head>
   <meta http-equiv="X-UA-Compatible" content="IE=Edge">
   <meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
+  <meta http-equiv="CACHE-CONTROL" content="NO-CACHE">
+  <meta http-equiv="EXPIRES" content="Mon, 01 Jan 1997 01:00:00 GMT">
+  <meta http-equiv="PRAGMA" content="NO-CACHE">
   
   <title>openDCIM Data Center Information Management</title>
   <link rel="stylesheet" href="css/inventory.php" type="text/css">

--- a/pathmaker.php
+++ b/pathmaker.php
@@ -406,6 +406,9 @@
 <head>
   <meta http-equiv="X-UA-Compatible" content="IE=Edge">
   <meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
+  <meta http-equiv="CACHE-CONTROL" content="NO-CACHE">
+  <meta http-equiv="EXPIRES" content="Mon, 01 Jan 1997 01:00:00 GMT">
+  <meta http-equiv="PRAGMA" content="NO-CACHE">
   
   <title>openDCIM Data Center Inventory</title>
   <link rel="stylesheet" href="css/inventory.php" type="text/css">

--- a/paths.php
+++ b/paths.php
@@ -500,6 +500,9 @@ if(isset($_GET['pathonly'])){
 <head>
   <meta http-equiv="X-UA-Compatible" content="IE=Edge">
   <meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
+  <meta http-equiv="CACHE-CONTROL" content="NO-CACHE">
+  <meta http-equiv="EXPIRES" content="Mon, 01 Jan 1997 01:00:00 GMT">
+  <meta http-equiv="PRAGMA" content="NO-CACHE">
   
   <title>openDCIM Data Center Inventory</title>
   <link rel="stylesheet" href="css/inventory.php" type="text/css">

--- a/people_depts.php
+++ b/people_depts.php
@@ -42,6 +42,9 @@
 <head>
   <meta http-equiv="X-UA-Compatible" content="IE=Edge">
   <meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
+  <meta http-equiv="CACHE-CONTROL" content="NO-CACHE">
+  <meta http-equiv="EXPIRES" content="Mon, 01 Jan 1997 01:00:00 GMT">
+  <meta http-equiv="PRAGMA" content="NO-CACHE">
   
   <title><?php __("openDCIM Department Membership Maintenance"); ?></title>
   <link rel="stylesheet" href="css/inventory.php" type="text/css">

--- a/power_panel.php
+++ b/power_panel.php
@@ -124,6 +124,9 @@
 <head>
   <meta http-equiv="X-UA-Compatible" content="IE=Edge">
   <meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
+  <meta http-equiv="CACHE-CONTROL" content="NO-CACHE">
+  <meta http-equiv="EXPIRES" content="Mon, 01 Jan 1997 01:00:00 GMT">
+  <meta http-equiv="PRAGMA" content="NO-CACHE">
   
   <title>openDCIM Data Center Management</title>
   <link rel="stylesheet" href="css/inventory.php" type="text/css">

--- a/rackrequest.php
+++ b/rackrequest.php
@@ -74,7 +74,7 @@
 		$logo='images/'.$config->ParameterArray["PDFLogoFile"];
 		$logo=$message->embed(Swift_Image::fromPath($logo)->setFilename('logo.png'));
 
-		$htmlMessage='<!doctype html><html><head><meta http-equiv="Content-Type" content="text/html; charset=UTF-8"><title>ITS Data Center Inventory</title></head><body><div id="header" style="padding: 5px 0;background: '.$config->ParameterArray["HeaderColor"].';"><center><img src="'.$logo.'"></center></div><div class="page"><p><h3>'.__("ITS Facilities Rack Request").'</h3>'."\n";
+		$htmlMessage='<!doctype html><html><head><meta http-equiv="Content-Type" content="text/html; charset=UTF-8"><meta http-equiv="CACHE-CONTROL" content="NO-CACHE"><meta http-equiv="EXPIRES" content="Mon, 01 Jan 1997 01:00:00 GMT"><meta http-equiv="PRAGMA" content="NO-CACHE"><title>ITS Data Center Inventory</title></head><body><div id="header" style="padding: 5px 0;background: '.$config->ParameterArray["HeaderColor"].';"><center><img src="'.$logo.'"></center></div><div class="page"><p><h3>'.__("ITS Facilities Rack Request").'</h3>'."\n";
 
 		if($_POST['action'] == 'Create'){
 			$req->RequestorID=$_POST['requestorid'];
@@ -199,6 +199,9 @@
 <head>
   <meta http-equiv="X-UA-Compatible" content="IE=Edge">
   <meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
+  <meta http-equiv="CACHE-CONTROL" content="NO-CACHE">
+  <meta http-equiv="EXPIRES" content="Mon, 01 Jan 1997 01:00:00 GMT">
+  <meta http-equiv="PRAGMA" content="NO-CACHE">
   
   <title>openDCIM Facilities Cabinet Maintenance</title>
   <link rel="stylesheet" href="css/inventory.php" type="text/css">

--- a/report-em_new_installs.php
+++ b/report-em_new_installs.php
@@ -40,7 +40,7 @@
 	$logo=getcwd().'/images/'.$config->ParameterArray["PDFLogoFile"];
 	$logo=$message->embed(Swift_Image::fromPath($logo)->setFilename('logo.png'));
 
-	$htmlMessage = sprintf( "<!doctype html><html><head><meta http-equiv=\"Content-Type\" content=\"text/html; charset=UTF-8\"><title>ITS Data Center Inventory</title></head><body><div id=\"header\" style=\"padding: 5px 0;background: %s;\"><center><img src=\"%s\"></center></div><div class=\"page\"><p><h3>Installations in the Past 7 Days</h3>\n", $config->ParameterArray["HeaderColor"], $logo );
+	$htmlMessage = sprintf( "<!doctype html><html><head><meta http-equiv=\"Content-Type\" content=\"text/html; charset=UTF-8\"><meta http-equiv=\"CACHE-CONTROL\" content=\"NO-CACHE\"><meta http-equiv=\"expires\" content=\"Mon, 01 Jan 1997 01:00:00 GMT\"><meta http-equiv=\"PRAGMA\" content=\"NO-CACHE\"><title>ITS Data Center Inventory</title></head><body><div id=\"header\" style=\"padding: 5px 0;background: %s;\"><center><img src=\"%s\"></center></div><div class=\"page\"><p><h3>Installations in the Past 7 Days</h3>\n", $config->ParameterArray["HeaderColor"], $logo );
 	
 	$htmlMessage .= sprintf( "<p>The following systems have been entered into openDCIM, with an Install Date set to within the past %d days.  Please review these entries to determine if follow-up documentation is required.</p>", $config->ParameterArray["NewInstallsPeriod"] );
 	

--- a/report_audit.php
+++ b/report_audit.php
@@ -138,6 +138,9 @@ if(!isset($_REQUEST['action'])){
 <head>
   <meta http-equiv="X-UA-Compatible" content="IE=Edge">
   <meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
+  <meta http-equiv="CACHE-CONTROL" content="NO-CACHE">
+  <meta http-equiv="EXPIRES" content="Mon, 01 Jan 1997 01:00:00 GMT">
+  <meta http-equiv="PRAGMA" content="NO-CACHE">
   
   <title>openDCIM Inventory Reporting</title>
   <link rel="stylesheet" href="css/inventory.php" type="text/css">

--- a/report_audit_frequency.php
+++ b/report_audit_frequency.php
@@ -123,6 +123,9 @@ if(!isset($_REQUEST['action'])){
 <head>
   <meta http-equiv="X-UA-Compatible" content="IE=Edge">
   <meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
+  <meta http-equiv="CACHE-CONTROL" content="NO-CACHE">
+  <meta http-equiv="EXPIRES" content="Mon, 01 Jan 1997 01:00:00 GMT">
+  <meta http-equiv="PRAGMA" content="NO-CACHE">
   
   <title>openDCIM Inventory Reporting</title>
   <link rel="stylesheet" href="css/inventory.php" type="text/css">

--- a/report_cabinets.php
+++ b/report_cabinets.php
@@ -24,6 +24,9 @@
 <head>
     <meta http-equiv="X-UA-Compatible" content="IE=Edge">
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
+    <meta http-equiv="CACHE-CONTROL" content="NO-CACHE">
+    <meta http-equiv="EXPIRES" content="Mon, 01 Jan 1997 01:00:00 GMT">
+    <meta http-equiv="PRAGMA" content="NO-CACHE">
 
     <title>openDCIM Inventory Reporting</title>
     <link rel="stylesheet" href="css/inventory.php" type="text/css">

--- a/report_logging.php
+++ b/report_logging.php
@@ -98,6 +98,9 @@ if(isset($_POST['refresh'])){
 <head>
   <meta http-equiv="X-UA-Compatible" content="IE=Edge">
   <meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
+  <meta http-equiv="CACHE-CONTROL" content="NO-CACHE">
+  <meta http-equiv="EXPIRES" content="Mon, 01 Jan 1997 01:00:00 GMT">
+  <meta http-equiv="PRAGMA" content="NO-CACHE">
   <link rel="stylesheet" href="css/inventory.php" type="text/css">
   <link rel="stylesheet" href="css/print.css" type="text/css" media="print">
   <link rel="stylesheet" href="css/jquery-ui.css" type="text/css">

--- a/report_network_map.php
+++ b/report_network_map.php
@@ -51,7 +51,7 @@
         );
         $deviceTypes = array(
                 'Server','Appliance','Storage Array','Switch','Chassis',
-                'Patch Panel','Physical Infrastructure','CDU','Sensor'
+                'Patch Panel','Physical Infrastructure','CDU','Sensor','WiFi AP','Router'
         );
         # handle the request variables and build the device lists.
         if(isset($_REQUEST['containerid'])){
@@ -566,6 +566,9 @@ overlap = scale;
 <head>
   <meta http-equiv="X-UA-Compatible" content="IE=Edge">
   <meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
+  <meta http-equiv="CACHE-CONTROL" content="NO-CACHE">
+  <meta http-equiv="EXPIRES" content="Mon, 01 Jan 1997 01:00:00 GMT">
+  <meta http-equiv="PRAGMA" content="NO-CACHE">
   <link rel="stylesheet" href="css/inventory.php" type="text/css">
   <link rel="stylesheet" href="css/print.css" type="text/css" media="print">
   <link rel="stylesheet" href="css/jquery-ui.css" type="text/css">

--- a/report_outage_simulator.php
+++ b/report_outage_simulator.php
@@ -15,6 +15,9 @@ if (!isset($_REQUEST['action'])){
 <head>
   <meta http-equiv="X-UA-Compatible" content="IE=Edge">
   <meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
+  <meta http-equiv="CACHE-CONTROL" content="NO-CACHE">
+  <meta http-equiv="EXPIRES" content="Mon, 01 Jan 1997 01:00:00 GMT">
+  <meta http-equiv="PRAGMA" content="NO-CACHE">
   <title>openDCIM Inventory Reporting</title>
   <link rel="stylesheet" href="css/inventory.php" type="text/css">
   <link rel="stylesheet" href="css/jquery-ui.css" type="text/css">

--- a/report_panel_schedule.php
+++ b/report_panel_schedule.php
@@ -25,6 +25,9 @@
 <head>
     <meta http-equiv="X-UA-Compatible" content="IE=Edge">
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
+    <meta http-equiv="CACHE-CONTROL" content="NO-CACHE">
+    <meta http-equiv="EXPIRES" content="Mon, 01 Jan 1997 01:00:00 GMT">
+    <meta http-equiv="PRAGMA" content="NO-CACHE">
   
     <title>openDCIM Inventory Reporting</title>
     <link rel="stylesheet" href="css/inventory.php" type="text/css">

--- a/report_surplus.php
+++ b/report_surplus.php
@@ -138,6 +138,9 @@ if(!isset($_REQUEST['action'])){
 <head>
   <meta http-equiv="X-UA-Compatible" content="IE=Edge">
   <meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
+  <meta http-equiv="CACHE-CONTROL" content="NO-CACHE">
+  <meta http-equiv="EXPIRES" content="Mon, 01 Jan 1997 01:00:00 GMT">
+  <meta http-equiv="PRAGMA" content="NO-CACHE">
   
   <title>openDCIM Inventory Reporting</title>
   <link rel="stylesheet" href="css/inventory.php" type="text/css">

--- a/report_tags.php
+++ b/report_tags.php
@@ -54,6 +54,9 @@
 <head>
   <meta http-equiv="X-UA-Compatible" content="IE=Edge">
   <meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
+  <meta http-equiv="CACHE-CONTROL" content="NO-CACHE">
+  <meta http-equiv="EXPIRES" content="Mon, 01 Jan 1997 01:00:00 GMT">
+  <meta http-equiv="PRAGMA" content="NO-CACHE">
   <link rel="stylesheet" href="css/inventory.php" type="text/css">
   <link rel="stylesheet" href="css/print.css" type="text/css" media="print">
   <link rel="stylesheet" href="css/jquery-ui.css" type="text/css">

--- a/report_xml_CFD.php
+++ b/report_xml_CFD.php
@@ -14,6 +14,9 @@
 <head>
   <meta http-equiv="X-UA-Compatible" content="IE=Edge">
   <meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
+  <meta http-equiv="CACHE-CONTROL" content="NO-CACHE">
+  <meta http-equiv="EXPIRES" content="Mon, 01 Jan 1997 01:00:00 GMT">
+  <meta http-equiv="PRAGMA" content="NO-CACHE">
   
   <title>openDCIM Data Center Inventory</title>
   <link rel="stylesheet" href="css/inventory.php" type="text/css">
@@ -81,7 +84,7 @@ echo '			</select>
 	$cabList=$cab->ListCabinetsByDC();
 	
 	header('Content-type: text/xml');
-	header('Cache-Control: no-store, no-cache');
+	header('Cache-Control: no-store, NO-CACHE');
 	header('Content-Disposition: attachment; filename="opendcim.xml"');
 	
 	print "<?xml version=\"1.0\" encoding=\"ISO-8859-1\"?>\n<datacenter>\n

--- a/reports.php
+++ b/reports.php
@@ -9,6 +9,9 @@
 <head>
   <meta http-equiv="X-UA-Compatible" content="IE=Edge">
   <meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
+  <meta http-equiv="CACHE-CONTROL" content="NO-CACHE">
+  <meta http-equiv="EXPIRES" content="Mon, 01 Jan 1997 01:00:00 GMT">
+  <meta http-equiv="PRAGMA" content="NO-CACHE">
 
   <title>openDCIM Inventory Reporting</title>
   <link rel="stylesheet" href="css/inventory.php" type="text/css">

--- a/repository_sync_ui.php
+++ b/repository_sync_ui.php
@@ -29,6 +29,9 @@
 <head>
   <meta http-equiv="X-UA-Compatible" content="IE=Edge">
   <meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
+  <meta http-equiv="CACHE-CONTROL" content="NO-CACHE">
+  <meta http-equiv="EXPIRES" content="Mon, 01 Jan 1997 01:00:00 GMT">
+  <meta http-equiv="PRAGMA" content="NO-CACHE">
   
   <title>openDCIM Data Center Inventory</title>
   <link rel="stylesheet" href="css/inventory.php" type="text/css">

--- a/rowview.php
+++ b/rowview.php
@@ -92,6 +92,9 @@
 <head>
   <meta http-equiv="X-UA-Compatible" content="IE=Edge">
   <meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
+  <meta http-equiv="CACHE-CONTROL" content="NO-CACHE">
+  <meta http-equiv="EXPIRES" content="Mon, 01 Jan 1997 01:00:00 GMT">
+  <meta http-equiv="PRAGMA" content="NO-CACHE">
   
   <title><?php echo $title; ?></title>
   <link rel="stylesheet" href="css/inventory.php" type="text/css">

--- a/search.php
+++ b/search.php
@@ -328,6 +328,9 @@
 <head>
   <meta http-equiv="X-UA-Compatible" content="IE=Edge">
   <meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
+  <meta http-equiv="CACHE-CONTROL" content="NO-CACHE">
+  <meta http-equiv="EXPIRES" content="Mon, 01 Jan 1997 01:00:00 GMT">
+  <meta http-equiv="PRAGMA" content="NO-CACHE">
   
   <title>openDCIM Search Results</title>
   <link rel="stylesheet" href="css/inventory.php" type="text/css">

--- a/search_export.php
+++ b/search_export.php
@@ -129,6 +129,9 @@
 <head>
   <meta http-equiv="X-UA-Compatible" content="IE=Edge">
   <meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
+  <meta http-equiv="CACHE-CONTROL" content="NO-CACHE">
+  <meta http-equiv="EXPIRES" content="Mon, 01 Jan 1997 01:00:00 GMT">
+  <meta http-equiv="PRAGMA" content="NO-CACHE">
   <link rel="stylesheet" href="css/inventory.php" type="text/css">
   <link rel="stylesheet" href="css/print.css" type="text/css" media="print">
   <link rel="stylesheet" href="css/jquery-ui.css" type="text/css">

--- a/storageroom.php
+++ b/storageroom.php
@@ -33,6 +33,9 @@
 <head>
   <meta http-equiv="X-UA-Compatible" content="IE=Edge">
   <meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
+  <meta http-equiv="CACHE-CONTROL" content="NO-CACHE">
+  <meta http-equiv="EXPIRES" content="Mon, 01 Jan 1997 01:00:00 GMT">
+  <meta http-equiv="PRAGMA" content="NO-CACHE">
   
   <title><?php echo __("Storage Room Maintenance");?></title>
   <link rel="stylesheet" href="css/inventory.php" type="text/css">

--- a/supplies.php
+++ b/supplies.php
@@ -64,6 +64,9 @@
 <head>
   <meta http-equiv="X-UA-Compatible" content="IE=Edge">
   <meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
+  <meta http-equiv="CACHE-CONTROL" content="NO-CACHE">
+  <meta http-equiv="EXPIRES" content="Mon, 01 Jan 1997 01:00:00 GMT">
+  <meta http-equiv="PRAGMA" content="NO-CACHE">
   
   <title>openDCIM Stockroom Supplies</title>
   <link rel="stylesheet" href="css/inventory.php" type="text/css">

--- a/supplybin.php
+++ b/supplybin.php
@@ -96,6 +96,9 @@
 <head>
   <meta http-equiv="X-UA-Compatible" content="IE=Edge">
   <meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
+  <meta http-equiv="CACHE-CONTROL" content="NO-CACHE">
+  <meta http-equiv="EXPIRES" content="Mon, 01 Jan 1997 01:00:00 GMT">
+  <meta http-equiv="PRAGMA" content="NO-CACHE">
   
   <title>openDCIM Stockroom Supplies</title>
 

--- a/supplycheckout.php
+++ b/supplycheckout.php
@@ -41,6 +41,9 @@
 <head>
   <meta http-equiv="X-UA-Compatible" content="IE=Edge">
   <meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
+  <meta http-equiv="CACHE-CONTROL" content="NO-CACHE">
+  <meta http-equiv="EXPIRES" content="Mon, 01 Jan 1997 01:00:00 GMT">
+  <meta http-equiv="PRAGMA" content="NO-CACHE">
   
   <title>openDCIM Stockroom Supplies</title>
   <link rel="stylesheet" href="css/inventory.php" type="text/css">

--- a/template.php
+++ b/template.php
@@ -12,6 +12,9 @@
 <head>
   <meta http-equiv="X-UA-Compatible" content="IE=Edge">
   <meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
+  <meta http-equiv="CACHE-CONTROL" content="NO-CACHE">
+  <meta http-equiv="EXPIRES" content="Mon, 01 Jan 1997 01:00:00 GMT">
+  <meta http-equiv="PRAGMA" content="NO-CACHE">
   
   <title>openDCIM Data Center Inventory</title>
   <link rel="stylesheet" href="css/inventory.php" type="text/css">

--- a/template_mpdf_reports.inc.php
+++ b/template_mpdf_reports.inc.php
@@ -30,6 +30,9 @@
 <head>
   <meta http-equiv="X-UA-Compatible" content="IE=Edge">
   <meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
+  <meta http-equiv="CACHE-CONTROL" content="NO-CACHE">
+  <meta http-equiv="EXPIRES" content="Mon, 01 Jan 1997 01:00:00 GMT">
+  <meta http-equiv="PRAGMA" content="NO-CACHE">
 
   <style>
     body {

--- a/timeperiods.php
+++ b/timeperiods.php
@@ -43,6 +43,9 @@
 <head>
   <meta http-equiv="X-UA-Compatible" content="IE=Edge">
   <meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
+  <meta http-equiv="CACHE-CONTROL" content="NO-CACHE">
+  <meta http-equiv="EXPIRES" content="Mon, 01 Jan 1997 01:00:00 GMT">
+  <meta http-equiv="PRAGMA" content="NO-CACHE">
   
   <title>openDCIM Data Center Inventory</title>
   <link rel="stylesheet" href="css/inventory.php" type="text/css">

--- a/updatevmowner.php
+++ b/updatevmowner.php
@@ -40,6 +40,9 @@
 <head>
   <meta http-equiv="X-UA-Compatible" content="IE=Edge">
   <meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
+  <meta http-equiv="CACHE-CONTROL" content="NO-CACHE">
+  <meta http-equiv="EXPIRES" content="Mon, 01 Jan 1997 01:00:00 GMT">
+  <meta http-equiv="PRAGMA" content="NO-CACHE">
   
   <title>openDCIM Device Maintenance</title>
   <link rel="stylesheet" href="css/inventory.php" type="text/css">

--- a/usermgr.php
+++ b/usermgr.php
@@ -70,6 +70,9 @@
 <head>
   <meta http-equiv="X-UA-Compatible" content="IE=Edge">
   <meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
+  <meta http-equiv="CACHE-CONTROL" content="NO-CACHE">
+  <meta http-equiv="EXPIRES" content="Mon, 01 Jan 1997 01:00:00 GMT">
+  <meta http-equiv="PRAGMA" content="NO-CACHE">
   
   <title>openDCIM User Manager</title>
   <link rel="stylesheet" href="css/inventory.php" type="text/css">

--- a/workorder.php
+++ b/workorder.php
@@ -24,6 +24,9 @@
 <head>
   <meta http-equiv="X-UA-Compatible" content="IE=Edge">
   <meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
+  <meta http-equiv="CACHE-CONTROL" content="NO-CACHE">
+  <meta http-equiv="EXPIRES" content="Mon, 01 Jan 1997 01:00:00 GMT">
+  <meta http-equiv="PRAGMA" content="NO-CACHE">
   
   <title>openDCIM Data Center Inventory</title>
   <link rel="stylesheet" href="css/inventory.php" type="text/css">

--- a/zone.php
+++ b/zone.php
@@ -75,6 +75,9 @@
 <head>
   <meta http-equiv="X-UA-Compatible" content="IE=Edge">
   <meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
+  <meta http-equiv="CACHE-CONTROL" content="NO-CACHE">
+  <meta http-equiv="EXPIRES" content="Mon, 01 Jan 1997 01:00:00 GMT">
+  <meta http-equiv="PRAGMA" content="NO-CACHE">
   
   <title><?php echo __("openDCIM Data Center Zones"); ?></title>
 

--- a/zone_stats.php
+++ b/zone_stats.php
@@ -135,6 +135,9 @@ $(document).ready(function() {
 <head>
   <meta http-equiv="X-UA-Compatible" content="IE=Edge">
   <meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
+  <meta http-equiv="CACHE-CONTROL" content="NO-CACHE">
+  <meta http-equiv="EXPIRES" content="Mon, 01 Jan 1997 01:00:00 GMT">
+  <meta http-equiv="PRAGMA" content="NO-CACHE">
   
   <title>openDCIM Data Center Information Management</title>
   <link rel="stylesheet" href="css/inventory.php" type="text/css">


### PR DESCRIPTION
For all HTML pages being rendered, pragma no-cache and cache expiry meta tags were added. This helps when images or content has changed but does not reflect in the browser during refresh due to browser caching.

Added  2 new Device types "WiFi AP, Router" to the Device type arrays.
