### PR TITLE
Add start any number on first unit (v2)

### DIFF
--- a/assets.inc.php
+++ b/assets.inc.php
@@ -38,6 +38,7 @@ class Cabinet {
 	var $ZoneID;
 	var $CabRowID;      //JMGA: Row of this cabinet
 	var $CabinetHeight;
+	var $StartUNum; // Number on first unit
 	var $Model;
 	var $Keylock;
 	var $MaxKW;
@@ -60,6 +61,7 @@ class Cabinet {
 		$this->ZoneID=intval($this->ZoneID);
 		$this->CabRowID=intval($this->CabRowID);
 		$this->CabinetHeight=intval($this->CabinetHeight);
+		$this->StartUNum=intval($this->StartUNum);
 		$this->Model=sanitize($this->Model);
 		$this->Keylock=sanitize($this->Keylock);
 		$this->MaxKW=floatval($this->MaxKW);
@@ -95,6 +97,7 @@ class Cabinet {
 		$cab->ZoneID=$dbRow["ZoneID"];
 		$cab->CabRowID=$dbRow["CabRowID"];
 		$cab->CabinetHeight=$dbRow["CabinetHeight"];
+		$cab->StartUNum=$dbRow["StartUNum"];
 		$cab->Model=$dbRow["Model"];
 		$cab->Keylock=$dbRow["Keylock"];
 		$cab->MaxKW=$dbRow["MaxKW"];
@@ -154,7 +157,7 @@ class Cabinet {
 		$sql="INSERT INTO fac_Cabinet SET DataCenterID=$this->DataCenterID, 
 			Location=\"$this->Location\", LocationSortable=\"$this->LocationSortable\",
 			AssignedTo=$this->AssignedTo, ZoneID=$this->ZoneID, CabRowID=$this->CabRowID, 
-			CabinetHeight=$this->CabinetHeight, Model=\"$this->Model\", 
+			CabinetHeight=$this->CabinetHeight, StartUNum=$this->StartUNum, Model=\"$this->Model\", 
 			Keylock=\"$this->Keylock\", MaxKW=$this->MaxKW, MaxWeight=$this->MaxWeight, 
 			InstallationDate=\"".date("Y-m-d", strtotime($this->InstallationDate))."\", 
 			MapX1=$this->MapX1, MapY1=$this->MapY1, 
@@ -187,7 +190,7 @@ class Cabinet {
 		$sql="UPDATE fac_Cabinet SET DataCenterID=$this->DataCenterID, 
 			Location=\"$this->Location\", LocationSortable=\"$this->LocationSortable\",
 			AssignedTo=$this->AssignedTo, ZoneID=$this->ZoneID, CabRowID=$this->CabRowID, 
-			CabinetHeight=$this->CabinetHeight, Model=\"$this->Model\", 
+			CabinetHeight=$this->CabinetHeight, StartUNum=$this->StartUNum, Model=\"$this->Model\", 
 			Keylock=\"$this->Keylock\", MaxKW=$this->MaxKW, MaxWeight=$this->MaxWeight, 
 			InstallationDate=\"".date("Y-m-d", strtotime($this->InstallationDate))."\", 
 			MapX1=$this->MapX1, MapY1=$this->MapY1, 
@@ -1647,9 +1650,9 @@ class Device {
 			$cab->CabinetID=$this->Cabinet;
 			$cab->GetCabinet();
 			if ( $newPosition == null ) {
-				$this->Position=$cab->CabinetHeight+1;
+				$this->Position = $cab->CabinetHeight+$cab->StartUNum;
 			} else {
-				$this->Position = $newPosition;
+				$this->Position = $cab->StartUNum+$newPosition-1;
 			}
 
 			$olddev=new Device();

--- a/cabinets.php
+++ b/cabinets.php
@@ -57,6 +57,7 @@
 		$cab->Notes=trim($_POST['notes']);
 		$cab->Notes=($cab->Notes=="<br>")?"":$cab->Notes;
 		$cab->U1Position=$_POST['u1position'];
+		$cab->StartUNum=$_POST['startunum'];
 
 		if ( $cab->U1Position == "Default" ) {
 			$dc = new DataCenter();
@@ -96,6 +97,7 @@
 		$cab->ZoneID=(isset($_GET['zoneid']))?intval($_GET['zoneid']):null;
 		$cab->CabRowID=(isset($_GET['cabrowid']))?intval($_GET['cabrowid']):null;
 		$cab->CabinetHeight=null;
+		$cab->StartUNum=$config->ParameterArray["StartUNum"];
 		$cab->Model=null;
 		$cab->Keylock=null;
 		$cab->MaxKW=null;
@@ -284,6 +286,9 @@ echo '  </select>
 <div>
    <div>',__("Cabinet Height"),' (U)</div>
    <div><input type="text" class="validate[optional,custom[onlyNumberSp]]" name="cabinetheight" size=4 maxlength=4 value="',$cab->CabinetHeight,'"></div>
+</div>
+<div>',__("Number on first unit"),' (U)</div>
+   <div><input type="text" class="validate[optional,custom[onlyNumberSp]]" name="startunum" size=4 maxlength=4 value="',$cab->StartUNum,'"></div>
 </div>
 <div>
    <div>',__("U1 Position"),'</div>

--- a/cabnavigator.php
+++ b/cabnavigator.php
@@ -235,6 +235,10 @@ function renderUnassignedTemplateOwnership($noTemplFlag, $noOwnerFlag, $device) 
 		$WeightColor=$CriticalColor;
 	}
 
+	if ($cab->StartUNum!=1) {
+		$legend.='<div class="legenditem"><span class="start_unit_number">'.__("Number on first unit").'</span> - '.$cab->StartUNum.'</div>'."\n";
+	}
+
 	foreach(Department::GetDepartmentListIndexedbyID() as $deptid => $d){
 		if($d->DeptColor!="#FFFFFF"){
             // If head is empty then we don't have any custom colors defined above so add a style container for these
@@ -442,7 +446,7 @@ echo $head,'  <script type="text/javascript" src="scripts/jquery.min.js"></scrip
   <script type="text/javascript" src="scripts/common.js"></script>
   <script type="text/javascript" src="scripts/masonry.pkgd.min.js"></script>
   <script type="text/javascript">
-	window.weight=',$totalWeight,';
+	window.weight="',$totalWeight,'";
 	var form=$("<form>").attr({ method: "post", action: "cabnavigator.php" });
 	$("<input>").attr({ type: "hidden", name: "cabinetid", value: "',$cab->CabinetID,'"}).appendTo(form);
 

--- a/configuration.php
+++ b/configuration.php
@@ -1354,6 +1354,10 @@ echo '<div class="main">
 					</div>
 				</div>
 				<div>
+					<div><label for="StartUNum">',__("Number on first unit"),'</label></div>
+					<div><input type="text" defaultvalue="',$config->defaults["StartUNum"],'" name="StartUNum" value="',$config->ParameterArray["StartUNum"],'"></div>
+				</div>
+				<div>
 					<div><label for="mUnits">',__("Measurement Units"),'</label></div>
 					<div><select id="mUnits" name="mUnits" defaultvalue="',$config->defaults["mUnits"],'" data="',$config->ParameterArray["mUnits"],'">
 							<option value="english"',(($config->ParameterArray["mUnits"]=="english")?' selected="selected"':''),'>',__("English"),'</option>

--- a/create.sql
+++ b/create.sql
@@ -12,6 +12,7 @@ CREATE TABLE fac_Cabinet (
   ZoneID int(11) NOT NULL,
   CabRowID int(11) NOT NULL,
   CabinetHeight int(11) NOT NULL,
+  StartUNum int(3) NOT NULL DEFAULT 1,
   Model varchar(80) NOT NULL,
   Keylock varchar(30) NOT NULL,
   MaxKW float(11) NOT NULL,
@@ -837,7 +838,8 @@ INSERT INTO fac_Config VALUES
 	('v3AuthProtocol', '', 'SHA/MD5', 'string', 'SHA'),
 	('v3AuthPassphrase', '', 'Password', 'string', ''),
 	('v3PrivProtocol', '', 'SHA/MD5', 'string', 'SHA'),
-	('v3PrivPassphrase', '', 'Password', 'string', '')
+	('v3PrivPassphrase', '', 'Password', 'string', ''),
+	('StartUNum','1','','int','1')
 ;
 
 --

--- a/db-4.1-to-4.2.sql
+++ b/db-4.1-to-4.2.sql
@@ -24,3 +24,9 @@ INSERT INTO fac_Config SET Parameter="PatchPanelsOnly", Value="enabled", UnitOfM
 -- Bump up the database version (uncomment below once released)
 --
 -- UPDATE fac_Config set Value="4.2" WHERE Parameter="Version";
+
+--
+-- Add feature "start any number on first unit"
+--
+ALTER TABLE fac_Cabinet ADD COLUMN StartUNum int(3) NOT NULL DEFAULT "1" AFTER CabinetHeight;
+INSERT INTO fac_Config VALUES('StartUNum',1,'','int',1);

--- a/report_asset_Excel.php
+++ b/report_asset_Excel.php
@@ -1095,6 +1095,8 @@ function computeSheetBodyDCInventory($DProps)
                 $rowName = getRowName($cab);
                 addRackStat($invCab, $cab, $cabinetColumns, $dc, $dcContainerList);
                 $cab_height = $cab->CabinetHeight;
+                $cab_start_unum = $cab->StartUNum;
+                $cab_top = $cab_height + $cab_start_unum - 1;
                 if (mb_strtoupper($cab->Model) == 'RESERVED') {
                     $dcStats['Rk_Res']++;
                 } else {
@@ -1104,27 +1106,27 @@ function computeSheetBodyDCInventory($DProps)
                 $device->Cabinet = $cab->CabinetID;
                 $device_list = $device->ViewDevicesByCabinet();
                 // empty cabinet
-                if ((count($device_list) == 0) && ($cab->CabinetHeight > 0)) {
+                if ((count($device_list) == 0) && ($cab_height > 0)) {
                     $dcStats['Rk_UtE'] += $cab_height;
                     $devSpec = makeEmptySpec($sheetColumns, $dcContainerList);
                     $devSpec['Zone'] = $zoneName;
                     $devSpec['Row'] = $rowName;
                     $devSpec['DC Name'] = $dc->Name;
                     $devSpec['Cabinet'] = $cab->Location;
-                    $devSpec['Position'] = 1;
-                    $devSpec['Height'] = $cab->CabinetHeight;
+                    $devSpec['Position'] = $cab_start_unum;
+                    $devSpec['Height'] = $cab_height;
                     $devSpec['Device'] = '__EMPTY';
                     $invData[] = $devSpec;
                 } else {
                     usort($device_list, 'cmpDevPos');
-                    $low_idx = 1;
+                    $low_idx = $cab_start_unum;
                     foreach ($device_list as $dev) {
                         if ($low_idx < $dev->Position) {
                             // range of empty slots
                             if ($dev->Position <= $cab_height) {
                                 $height = $dev->Position - $low_idx;
                             } else {
-                                $height = $cab_height - $low_idx + 1;
+                                $height = $cab_top - $low_idx;
                             }
                             if ($height > 0) {
                                 $dcStats['Rk_UtE'] += $height;

--- a/report_cabinets.php
+++ b/report_cabinets.php
@@ -110,7 +110,7 @@
         foreach ( $cabList as $cab ) {
             print "<div><div><input type=\"checkbox\" class=\"selectedId\" id=\"selectedId\" name=\"cabinetid[]\" value=\"$cab->CabinetID\">$cab->Location</input></div></div>\n";
         }
-    }        
+    }
 ?>
 </div>
 </form>
@@ -167,6 +167,8 @@
                 $noTemplFlag, $noOwnerFlag;
 
         $currentHeight=$cabinet->CabinetHeight;
+        $currentStartUNum=$cabinet->StartUNum;
+        $currentStopUNum=($currentStartUNum+$currentHeight-1);
 
         // Determine which label to put on the rack, if any
         $rs="";
@@ -210,12 +212,17 @@
                 if($device->Reservation==true){
                     $reserved=" reserved";
                 }
-                if($devTop<$currentHeight && $currentHeight>0){
-                    for($i=$currentHeight;($i>$devTop);$i--){
-                        $errclass=($i>$cabinet->CabinetHeight)?' error':'';
+                if($devTop<$currentStopUNum && $currentStopUNum>($currentStartUNum-1)){
+                    if ($devTop>0){ // If device installed not in zero unit
+                        $Rows=$devTop;
+                    } else {
+                        $Rows=$currentStartUNum-1;
+                    }
+                    for($i=$currentStopUNum;($i>$Rows);$i--){
+                        $errclass=($i>$currentStartUNum)?' error':'';
                         if($errclass!=''){$heighterr="yup";}
-                        if($i==$currentHeight && $i>1){
-                            $blankHeight=$currentHeight-$devTop;
+                        if($i==$currentStopUNum && $i>1){
+                            $blankHeight=$currentStopUNum-$devTop;
                             if($devTop==-1){--$blankHeight;}
                             $body.="\t\t<tr><td class=\"cabpos freespace$errclass\">$i</td><td class=\"freespace\" rowspan=$blankHeight>&nbsp;</td></tr>\n";
                         } else {
@@ -225,7 +232,7 @@
                     }
                 }
                 for($i=$devTop;$i>=$device->Position;$i--){
-                    $errclass=($i>$cabinet->CabinetHeight)?' error':'';
+                    $errclass=($i>($cabinet->CabinetHeight+$cabinet->StartUNum))?' error':'';
                     if($errclass!=''){$heighterr="yup";}
                     if($i==$devTop){
                         // If we're looking at the side of the rack don't give any details but show the
@@ -250,18 +257,18 @@
                         $body.="\t\t<tr><td class=\"cabpos$reserved dept$device->Owner$errclass\">$i</td></tr>\n";
                     }
                 }
-                $currentHeight=$device->Position - 1;
+                $currentStopUNum=$device->Position - 1;
             }elseif(!$rear){
                 $backside=true;
             }
         }
 
         // Fill in to the bottom
-        for($i=$currentHeight;$i>0;$i--){
-            if($i==$currentHeight){
-                $blankHeight=$currentHeight;
-
+        for($i=$currentStopUNum;$i>($currentStartUNum-1);$i--){
+            if($i==$currentStopUNum){
+                $blankHeight=$currentStopUNum;
                 $body.="\t\t<tr><td class=\"cabpos freespace\">$i</td><td class=\"freespace\" rowspan=$blankHeight>&nbsp;</td></tr>\n";
+
             }else{
                 $body.="\t\t<tr><td class=\"cabpos freespace\">$i</td></tr>\n";
             }

--- a/scripts/ajax_cabinetuse.php
+++ b/scripts/ajax_cabinetuse.php
@@ -13,59 +13,69 @@
 	$cab->CabinetID=$dev->Cabinet=intval($_GET['cabinet']);
 	$devList=$dev->ViewDevicesByCabinet();
 	$cab->GetCabinet();
+	$deviceMinPos=$cab->StartUNum;
+	$deviceMaxPos=$cab->CabinetHeight+$cab->StartUNum-1;
+	$cabRowsMax=$cab->CabinetHeight+$cab->StartUNum-1;
+	$cabRowsMin=$cab->StartUNum;
+	$currentDevList=$devList;
 
-	function MarkUsed($dev,&$cabarray){
-		$i=$dev->Height;
+	foreach ($currentDevList as $currentDevice) {
+		if (($currentDevice->Position-$currentDevice->Height+1) < $deviceMinPos){
+			$cabRowsMin=($cabRowsMin>$currentDevice->Position-$currentDevice->Height+1)?$currentDevice->Position-$currentDevice->Height+1:$cabRowsMin;
+		} elseif ($currentDevice->Position+$currentDevice->Height-1 > $deviceMaxPos) {
+			$cabRowsMax=($cabRowsMax<$currentDevice->Position+$currentDevice->Height-1)?$currentDevice->Position+$currentDevice->Height-1:$cabRowsMax;
+		}
+	}
 
-		while($i>0){
-			$i--;
-			$u=$dev->Position+$i;
-			//constraight the rack usage to just what is a valid rack position
-			if($u<=max(array_keys($cabarray)) && $u>=1){
-				$cabarray[$u]=true;
+	function MarkUsed($dev,&$cabarray,$cabRowsMax,$cabRowsMin){
+		for ($i=$dev->Height; $i>0; $i--) {
+			$u=$dev->Position-$i+1;
+			if($u<=max(array_keys($cabarray)) && $u>=$cabRowsMin){
+				$cabarray[$u]=$dev->DeviceID;
 			}
 		}
 	}
 	
 	// Fill in rack positions for true/false checks
 	$cabinetuse=array();
-	$i=$cab->CabinetHeight;
-	while($i>0){
+	for ($i=$cabRowsMax; $i>=$cabRowsMin; $i--) {
 		$cabinetuse[$i]=false;
-		$i--;
+
 	}
 
 	$dev->BackSide=(isset($_GET['BackSide']) && $_GET['BackSide']=='true')?true:false;
 	$dev->HalfDepth=(isset($_GET['HalfDepth']) && $_GET['HalfDepth']=='true')?true:false;
-	
+	$count = 0;
 	// Build array of each position used
 	foreach($devList as $key => $device) {
 		// Only count space occupied by devices other than the current one
-		if($dev->DeviceID!=$device->DeviceID && $device->Height >0){ 
+		if(($dev->DeviceID!=$device->DeviceID || $count==0) && $device->Height >0){
+			$count++;
 			// If we're dealing with a half depth device then we care to about similar
 			if($dev->HalfDepth){
 				// Since we're dealing with a half depth then we care about a particular rack face
 				if($dev->BackSide){
 					// half and full depth devices on the back of the rack
 					if(!$device->HalfDepth || ($device->HalfDepth && $device->BackSide)){
-						MarkUsed($device,$cabinetuse);
+						MarkUsed($device,$cabinetuse,$cabRowsMax,$cabRowsMin);
 					}
 				}else{
 					// half and full depth devices on the front of the rack
 					if(!$device->HalfDepth || ($device->HalfDepth && !$device->BackSide)){
-						MarkUsed($device,$cabinetuse);
+						MarkUsed($device,$cabinetuse,$cabRowsMax,$cabRowsMin);
 					}
 				}
 			}else{
-				MarkUsed($device,$cabinetuse);
+				MarkUsed($device,$cabinetuse,$cabRowsMax,$cabRowsMin);
 			}
 		}
 	}
 
-	$cabinetuse[0]=$cab->U1Position;
- 
 	// Reverse sort by rack position
 	krsort($cabinetuse);
+	$cabinetuse['UStart']=$cab->StartUNum;
+	$cabinetuse['UStop']=$cab->CabinetHeight+$cab->StartUNum-1;
+	$cabinetuse['U1Pos']=$cab->U1Position;
 	header('Content-Type: application/json');
 	echo json_encode($cabinetuse);
 ?>

--- a/scripts/common.js
+++ b/scripts/common.js
@@ -1350,8 +1350,30 @@ function initdrag(){
 	});
 }
 
+var getMinUnit = function (cab) {
+    var result = null;
+    $.ajax({
+        url: 'scripts/ajax_cabinetuse.php?cabinet='+cab,
+        success: function(data, textStatus, jqXHR){
+            var cabArrCount=Object.keys(data).length-4;
+            for(var i=cabArrCount; i>=0; i--){
+                if(i==cabArrCount){
+                    result=parseInt(Object.keys(data)[cabArrCount]);
+                }
+                if (parseInt(Object.keys(data)[i])<result){
+                    result=parseInt(Object.keys(data)[i]);
+                }
+            }
+        },
+        async: false
+    });
+    return result;
+};
+
+
 function InsertDevice(obj){
-	if(obj.Position!=0){
+	var devMinPosition=getMinUnit(obj.Cabinet);
+	if(obj.Position>=devMinPosition){
 		function getPic(insertobj,rear){
 			var showrear=(rear)?'?rear':'';
 			$.get('api/v1/device/'+obj.DeviceID+'/getpicture'+showrear).done(function(data){


### PR DESCRIPTION
Hi!
I fix bugs from previous version, and wrote new patch for adding "start any number on first unit" function.

Default settings:
![scr1](https://cloud.githubusercontent.com/assets/17050896/13109770/78619588-d58c-11e5-85fc-356d3e610b4a.png)

Cabinet settings:
![scr5](https://cloud.githubusercontent.com/assets/17050896/13109831/d363a75a-d58c-11e5-8404-4805d6a3c9cc.png)

Cabinet with bottom to top numeration:
![scr2](https://cloud.githubusercontent.com/assets/17050896/13109771/787b8df8-d58c-11e5-9fcd-752eeb40fd84.png)

Cabinet with top to bottom numeration:
![scr3](https://cloud.githubusercontent.com/assets/17050896/13109773/789fa422-d58c-11e5-9469-ff1bab8fc477.png)

Editing device:
![scr4](https://cloud.githubusercontent.com/assets/17050896/13109772/7895e270-d58c-11e5-899b-5f03824c2cc4.png)

Regards.
