### PR TITLE
Fix: underline character in name of devices is not visible?

### DIFF
--- a/css/inventory.php
+++ b/css/inventory.php
@@ -545,7 +545,7 @@ div.cabinet {
 } 
 .picture .label > div {text-align: center;width: 100%;}
 .picture .label > div,
-.picture div > a > div > div { top: 10%; height: 80%; padding-left: 0.3em;}
+.picture div > a > div > div { top: -6%; height: 80%; padding-left: 0.3em;}
 .picture div > a > div > div {overflow: hidden;}
 .picture div .label {overflow: hidden;}
 .label.noimage { margin: -2px; border: 2px solid black; }


### PR DESCRIPTION
Fix: underline character in name of devices is not visible in cabnavigator page. So fix 'top:' from 10% to -6%.
![underline](https://cloud.githubusercontent.com/assets/10425179/17588225/15f8fac4-5fd6-11e6-94d2-72f9a37bfd2a.png)
