### PR TITLE
Support HP Virtual Connect Ethernet Modules

### DIFF
--- a/classes/SwitchInfo.class.php
+++ b/classes/SwitchInfo.class.php
@@ -92,7 +92,7 @@ class SwitchInfo {
 		
 		$x=array();
 		foreach(self::OSS_SNMP_Lookup($dev,"names") as $index => $portdesc ) {
-			if ( preg_match( "/([0-9]\:|bond|\"[A-Z]|swp|eth|Ethernet|Port-Channel|\/)[0]{0,}?[01]$/", $portdesc )) {
+			if ( preg_match( "/([0-9]\:|bond|\"[A-Z]|swp|eth|Ethernet|Port-Channel|X|\/)[0]{0,}?[01]$/", $portdesc )) {
 				$x[$index] = $portdesc;
 			} // Find lines that end with /1
 		}


### PR DESCRIPTION
HP VC Ethernet Modules use `X[0-9]+` for their external port names.
![325e33dc-f6b2-11e6-9396-24eb91abb5ea](https://cloud.githubusercontent.com/assets/10375269/23125531/78114e6c-f772-11e6-8c4f-58b8bc6e4b8d.png)
![325f46dc-f6b2-11e6-833d-4dd573638779](https://cloud.githubusercontent.com/assets/10375269/23125534/805e0fce-f772-11e6-8f1b-720a646a330d.png)
