### PR TITLE
Find first Port support for Dell PowerConnect 35xx

### DIFF
--- a/classes/SwitchInfo.class.php
+++ b/classes/SwitchInfo.class.php
@@ -92,7 +92,7 @@ class SwitchInfo {
 		
 		$x=array();
 		foreach(self::OSS_SNMP_Lookup($dev,"names") as $index => $portdesc ) {
-			if ( preg_match( "/([0-9]\:|bond|\"[A-Z]|swp|eth|Ethernet|Port-Channel|X|\/)[0]{0,}?[01]$/", $portdesc )) {
+			if ( preg_match( "/([0-9]\:|bond|\"[A-Z]|swp|eth|e|Ethernet|Port-Channel|X|\/)[0]{0,}?[01]$/", $portdesc )) {
 				$x[$index] = $portdesc;
 			} // Find lines that end with /1
 		}


### PR DESCRIPTION
Interfaces on older Dell PowerConnect switches are named e1 - e48. This adds support for it in the regex.