### PR TITLE
Fixes an exception api/v1/getRoutes.php

### DIFF
--- a/api/v1/getRoutes.php
+++ b/api/v1/getRoutes.php
@@ -625,6 +625,8 @@ $app->get( '/project/bydevice/:deviceid', function($deviceid) {
 //
 
 $app->get( '/powerport/:deviceid', function($deviceid) {
+        global $app;
+
 	$pp=new PowerPorts();
 	
 	$r['error']=false;


### PR DESCRIPTION
exception 'ErrorException' with message 'Undefined variable: app' in /var/www/openDCIM/api/v1/getRoutes.php:633
Stack trace:
#0 /var/www/openDCIM/api/v1/getRoutes.php(633): Slim\Slim::handleErrors(8, 'Undefined varia...', '/var/www/openDC...', 633, Array)
#1 [internal function]: {closure}('0')
#2 /var/www/openDCIM/vendor/slim/slim/Slim/Route.php(468): call_user_func_array(Object(Closure), Array)
#3 /var/www/openDCIM/vendor/slim/slim/Slim/Slim.php(1357): Slim\Route->dispatch()
#4 /var/www/openDCIM/vendor/slim/slim/Slim/Middleware/Flash.php(85): Slim\Slim->call()
#5 /var/www/openDCIM/vendor/slim/slim/Slim/Middleware/MethodOverride.php(92): Slim\Middleware\Flash->call()
#6 /var/www/openDCIM/vendor/slim/slim/Slim/Middleware/PrettyExceptions.php(67): Slim\Middleware\MethodOverride->call()
#7 /var/www/openDCIM/vendor/slim/slim/Slim/Slim.php(1302): Slim\Middleware\PrettyExceptions->call()
#8 /var/www/openDCIM/api/v1/index.php(187): Slim\Slim->run()
#9 {main}
