### PR TITLE
Fix auth type check bug in API code

### DIFF
--- a/api/v1/index.php
+++ b/api/v1/index.php
@@ -132,7 +132,7 @@ $app->add(function($request, $response, $next) use($person) {
 
 //	Slim Framework 2 middleware
 $app->hook( 'slim.before.dispatch', function() use($person) {
-	if ( AUTHENTICATION == "LDAP" || "AD" ) {
+	if ( AUTHENTICATION == "LDAP" || AUTHENTICATION == "AD" ) {
 		// Getting request headers
 		$headers = apache_request_headers();
 		$response = array();


### PR DESCRIPTION
Previously 'if' condition always evaluated true regardless of AUTHENTICATION value, clearly not the intended behavior. (PHP operator precedence, non-empty, non-"0" string evaluates to a boolean TRUE)