### PR TITLE
division by zero bug

### DIFF
--- a/classes/DataCenter.class.php
+++ b/classes/DataCenter.class.php
@@ -416,7 +416,7 @@ class DataCenter {
 					$maxDraw*=0.8;
 
 					// Only keep the highest percentage of any single CDU in a cabinet
-					if ( $rp > 0 ) {
+					if ( $$maxDraw > 0 ) {
 						$pp=intval($rp / $maxDraw * 100);
 					} else {
 						$pp = 0;


### PR DESCRIPTION
Hi,

Cheking the code we saw that you intended to catch the invalid division by zero but the error was that the "if" was cheking the denominator and not the divisor.

PHP Warning:  Division by zero in /var/www/html/openDCIM/classes/DataCenter.class.php on line 420, referer: https://localhost/openDCIM/dc_stats.php?dc=4
