### PR TITLE
Patch for issue #885.

### DIFF
--- a/misc.inc.php
+++ b/misc.inc.php
@@ -129,9 +129,9 @@ function redirect($target = null) {
 		}
 	}
 	if(array_key_exists('HTTPS', $_SERVER) && $_SERVER["HTTPS"]=='on') {
-		$url = "https://".$_SERVER['HTTP_HOST'].$target;
+		$url = "https://".$_SERVER['SERVER_NAME'].$target;
 	} else {
-		$url = "http://".@$_SERVER['HTTP_HOST'].$target;
+		$url = "http://".@$_SERVER['SERVER_NAME'].$target;
 	}
 	return $url;
 }


### PR DESCRIPTION
Fixes the redirection to use the incoming URL, and not the hostname.
This is need when you run opendcim behind a proxy, a load balancer, or
as a Docker container.