### PR TITLE
Update datacenter Text Output To data center In RIGHTS File

### DIFF
--- a/RIGHTS
+++ b/RIGHTS
@@ -11,8 +11,8 @@ Read:
 Write:
 
 No Rights Management:
-	Display a map and basic stats for any datacenter (no menu):	dc_dashboard.php
-	Display a map and basic stats for any datacenter:			dc_stats.php
+	Display a map and basic stats for any data center (no menu):	dc_dashboard.php
+	Display a map and basic stats for any data center:				dc_stats.php
 		* need to check rights before adding the links to the racks
 
 Global Read:


### PR DESCRIPTION
In user visible output the phrase should be "data center" not
"datacenter".   Updating the few places the output is inconsistent is
much simpler than renaming the project openDIM.

This changeset alters the RIGHTS file text.