### PR TITLE
Update datacenter Text Output To data center In inventory.php

### DIFF
--- a/css/inventory.php
+++ b/css/inventory.php
@@ -143,7 +143,7 @@ div#imageselection { display: none;}
 
 
 
-/* Datacenter Stats */
+/* Data Center Stats */
 .dcstats .heading > div{width: 89%;display: inline-block;vertical-align: middle;}
 .dcstats .heading > div + div {width: 10%;}
 .dcstats .heading > div + div button {display: block;width: 100%;}


### PR DESCRIPTION
In user visible output the phrase should be "data center" not
"datacenter". Updating the few places the output is inconsistent is
much simpler than renaming the project openDIM.

This changeset alters the errornious comment in the css/inventory.php
file (which a user could see with view source I think).