### PR TITLE
Update datacenter Text Output To data center In en_US po File

### DIFF
--- a/locale/en_US/LC_MESSAGES/openDCIM.po
+++ b/locale/en_US/LC_MESSAGES/openDCIM.po
@@ -1865,7 +1865,7 @@ msgstr ""
 
 #: openDCIM/mapmaker.php:123
 msgid ""
-"You must configure an image for this datacenter before attempting to place a "
+"You must configure an image for this data center before attempting to place a "
 "cabinet on its map."
 msgstr ""
 
@@ -2594,7 +2594,7 @@ msgid "Device Label"
 msgstr ""
 
 #: openDCIM/report_tags.php:25
-msgid "Datacenter"
+msgid "Data Center"
 msgstr ""
 
 #: openDCIM/report_tags.php:26


### PR DESCRIPTION
In user visible output the phrase should be "data center" not
"datacenter". Updating the few places the output is inconsistent is
much simpler than renaming the project openDIM.

This changeset alters the en_US openDCIM.po file.  This is the file
which is used to generate the majority (all?) of the user visible text
on the web interface.