### PR TITLE
Fix $args is not defined error in API delete

### DIFF
--- a/api/v1/deleteRoutes.php
+++ b/api/v1/deleteRoutes.php
@@ -118,7 +118,7 @@ $app->delete( '/colorcode/:colorid', function( $colorid ) use($person) {
 
 $app->delete( '/device/:deviceid', function( $deviceid ) {
 	$dev=new Device();
-	$dev->DeviceID=$args['deviceid'];
+	$dev->DeviceID=$deviceid;
 	
 	if(!$dev->GetDevice()){
 		$r['error']=true;


### PR DESCRIPTION
Fixed legacy $args definition that breaks API delete.