### PR TITLE
Fix invalid json on device not found

### DIFF
--- a/api/v1/getRoutes.php
+++ b/api/v1/getRoutes.php
@@ -389,7 +389,6 @@ $app->get( '/device/:deviceid', function( $deviceid ) {
 		$r['error']=true;
 		$r['errorcode']=404;
 		$r['message']=__("No device found with DeviceID").$deviceid;
-		echoResponse( $r );
 	}else{
 		$r['error']=false;
 		$r['errorcode']=200;


### PR DESCRIPTION
Fix an invalid json response on the v1 api route `/api/v1/device/:deviceid` when the device is not found. Previously the response content would be duplicated in this case,
resulting in invalid json, for example, from a python client:

```
>>> r = c._get('api/v1/device/12045')
>>> r.json()
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/home/appelte1/.pyenv/versions/3.6.2/lib/python3.6/site-packages/requests/models.py", line 884, in json
    self.content.decode(encoding), **kwargs
  File "/home/appelte1/.pyenv/versions/3.6.2/lib/python3.6/json/__init__.py", line 354, in loads
    return _default_decoder.decode(s)
  File "/home/appelte1/.pyenv/versions/3.6.2/lib/python3.6/json/decoder.py", line 342, in decode
    raise JSONDecodeError("Extra data", s, end)
json.decoder.JSONDecodeError: Extra data: line 1 column 78 (char 77)
>>> r.text
'{"error":true,"errorcode":404,"message":"No device found with DeviceID12045"}{"error":true,"errorcode":404,"message":"No device found with DeviceID12045"}'
```