### PR TITLE
Add support for searching for User records by attribute not in DN.

### DIFF
--- a/api/v1/index.php
+++ b/api/v1/index.php
@@ -5,7 +5,7 @@
 	// Not really a loginPage, but this variable will keep us from getting redirected when
 	// using LDAP auth and there's no session (so true RESTful API capability)
 	//
-	if ( AUTHENTICATION == "LDAP" ) {
+	if ( AUTHENTICATION == "LDAP" || AUTHENTICATION == "AD") {
 		$loginPage = true;
 	}
 

--- a/configuration.php
+++ b/configuration.php
@@ -2134,6 +2134,10 @@ echo '<div class="main">
 					<div><input type="text" defaultvalue="',$config->defaults["LDAPBindDN"],'" name="LDAPBindDN" value="',$config->ParameterArray["LDAPBindDN"],'"></div>
 				</div>
 				<div>
+					<div><label for="LDAPBindPassword">',__("Bind Password"),'</label></div>
+					<div><input type="password" defaultvalue="',$config->defaults["LDAPBindPassword"],'" name="LDAPBindPassword" value="',$config->ParameterArray["LDAPBindPassword"],'"></div>
+				</div>
+				<div>
 					<div><label for="LDAPUserSearch">',__("User Search"),'</label></div>
 					<div><input type="text" defaultvalue="',$config->defaults["LDAPUserSearch"],'" name="LDAPUserSearch" value="',$config->ParameterArray["LDAPUserSearch"],'"></div>
 				</div>

--- a/create.sql
+++ b/create.sql
@@ -856,6 +856,7 @@ INSERT INTO fac_Config VALUES
   ('LDAPServer', 'localhost', 'URI', 'string', 'localhost'),
   ('LDAPBaseDN', 'dc=opendcim,dc=org', 'DN', 'string', 'dc=opendcim,dc=org'),
   ('LDAPBindDN', 'cn=%userid%,ou=users,dc=opendcim,dc=org', 'DN', 'string', 'cn=%userid%,ou=users,dc=opendcim,dc=org'),
+  ('LDAPBindPassword', '', 'Password', 'string', ''),
   ('LDAPBaseSearch', '(&(objectClass=posixGroup)(memberUid=%userid%))', 'DN', 'string', '(&(objectClass=posixGroup)(memberUid=%userid%))'),
   ('LDAPUserSearch', '(|(uid=%userid%))', 'DN', 'string', '(|(uid=%userid%))'),
   ('LDAPSessionExpiration', '0', 'Seconds', 'int', '0'),

--- a/login_ad.php
+++ b/login_ad.php
@@ -1,201 +1,224 @@
 <?php
-
-  /* Gets the members of the given group within the base DN.
-     Returns an array containing the members. */
-  function getLDAPGroupMembers(&$ldapConn, $baseDN, $groupDN) {
-	$ldapSearch = ldap_search($ldapConn, $baseDN, "(|(distinguishedName=$groupDN))", array("member"));
-	$ldapResults = ldap_get_entries($ldapConn, $ldapSearch);
-
-	return @$ldapResults[0]['member'];
-  }
-
-  /* Checks if a user's group is also a member of the group's group.
-     Returns true or false. */
-  function inLDAPGroup($groupGroups, $userGroups) {
-	// Remove the first element of the array.
-	// The first element will be the element count, as returned by ldap_get_entries().
-	@array_shift($groupGroups);
-	@array_shift($userGroups);
-
-	// If either the group groups or user groups are empty, return false.
-	if (empty($groupGroups) || empty($userGroups)) {
-		return false;
-	}
-
-	// Set all elements to lowercase.
-	$groupGroups = array_map('strtolower', $groupGroups);
-	$userGroups = array_map('strtolower', $userGroups);
-
-	// Flip the group groups array so the value becomes the key.
-	$groupGroups = array_flip($groupGroups);
-
-	// Use isset() because it's faster than in_array() and others.
-	foreach($userGroups as $userGroup) {
-		if (isset($groupGroups[$userGroup])) {
-			return true;
-		}
-	}
-
-	return false;
-  }
-
-  // Set a variable so that misc.inc.php knows not to throw us into an infinite redirect loop
+  define('LDAP_OPT_DIAGNOSTIC_MESSAGE', 0x0032);
   $loginPage = true;
-
-	require_once('db.inc.php');
-	require_once('facilities.inc.php');
-
-//	Uncomment these if you need/want to set a title in the header
-	$header=__("openDCIM Login");
-  $content = "";
+  require_once('db.inc.php');
+  require_once('facilities.inc.php');
+  $header = __('openDCIM Login');
   $person = new People();
+  $content = '';
+  $ldapConn = NULL;
+  $loginFailedMsg = '<h3>Login failed.  Incorrect username, password, or rights.</h3>';
 
-  if ( isset($_GET['logout'])) {
-    // Unfortunately session_destroy() doesn't actually clear out existing variables, so let's nuke from orbit
-    session_unset();
-    $_SESSION = array();
-    unset($_SESSION["userid"]);
-    session_destroy();
-    session_commit();
-    $content = "<h3>Logout successful.</h3>";
-  }
-
-  if ( isset($_POST['username'])) {
-    $ldapConn = ldap_connect( $config->ParameterArray['LDAPServer'] );
-    if ( ! $ldapConn ) {
-      $content = "<h3>Fatal error.  The LDAP server is not reachable.  Please try again later, or contact your system administrator to check the configuration.</h3>";
-      error_log( "Unable to connect to LDAP Server: " . $config->ParameterArray['LDAPServer']);
-    } else {
-      ldap_set_option( $ldapConn, LDAP_OPT_REFERRALS, 0 );
-      ldap_set_option( $ldapConn, LDAP_OPT_PROTOCOL_VERSION, 3 );
-
-      $ldapUser = htmlspecialchars($_POST['username']);
-      $ldapDN = str_replace( "%userid%", $ldapUser, $config->ParameterArray['LDAPBindDN']);
-      $ldapPassword = $_POST['password'];
-
-      $ldapBind = ldap_bind( $ldapConn, $ldapDN, $ldapPassword );
-
-      if ( ! $ldapBind ) {
-        $content = "<h3>Login failed.  Incorrect username, password, or rights.</h3>";
-	error_log("Login failed for $ldapUser. Incorrect username or password");
-      } else {
-        // User was able to authenticate, but might not have authorization to access openDCIM.  Here we check for those rights.
-        /* If this install doesn't have the new parameter, use the old default */
-        if ( !isset($config->ParameterArray['LDAPBaseSearch'])) {
-          $config->ParameterArray['LDAPBaseSearch'] = "(&(objectClass=posixGroup)(memberUid=%userid%))";
-        }
-
-        // Because we have audit logs to maintain, we need to make a local copy of the User's record
-        // to keep in the openDCIM database just in case the user gets removed from LDAP.  This also
-        // makes it easier to check access rights by replicating the user's rights from LDAP into the
-        // local db for the session.  Revoke all rights every login and pull a fresh set from LDAP.
-        $person->UserID = $ldapUser;
-        $person->GetPersonByUserID();
-        $person->revokeAll();
-
-        // Now get some more info about the user
-        // Insert the default 4.2 UserSearch string in case this is an upgrade instance
-        if ( ! isset($config->ParameterArray['LDAPUserSearch'])) {
-          $config->ParameterArray['LDAPUserSearch'] = "(|(uid=%userid%))";
-        }
-        $userSearch = str_replace( "%userid%", $ldapUser, html_entity_decode($config->ParameterArray['LDAPUserSearch']));
-        $ldapSearch = ldap_search( $ldapConn, $config->ParameterArray['LDAPBaseDN'], $userSearch );
-        $ldapResults = ldap_get_entries( $ldapConn, $ldapSearch );
-
-        // These are standard schema items, so they aren't configurable
-        // However, suppress any errors that may crop up from not finding them
-        $person->FirstName = @$ldapResults[0]['givenname'][0];
-        $person->LastName = @$ldapResults[0]['sn'][0];
-        $person->Email = @$ldapResults[0]['mail'][0];
-
-	// Get the user's DN.
-	$ldapUserDN = @$ldapResults[0]['dn'];
-	// Get the groups that the user is a member of.
-	$ldapUserGroups = @$ldapResults[0]['memberof'];
-	// Add the user's DN to the groups as well because they may have been added as a member of the group explicitly.
-	array_push($ldapUserGroups, $ldapUserDN);
-
-	// Check the different OpenDCIM priviledges and try to match.
-	// Lots of if statements here because a user could be a member of more than one group.
-	if ($config->ParameterArray['LDAPSiteAccess'] == "" || inLDAPGroup(getLDAPGroupMembers($ldapConn, $config->ParameterArray['LDAPBaseDN'], $config->ParameterArray['LDAPSiteAccess']), $ldapUserGroups)) {
-		// No specific group membership required to access openDCIM or they have a match to the group required
-		$_SESSION['userid'] = $ldapUser;
-		$_SESSION['LoginTime'] = time();
-		session_commit();
-	}
-
-	if (inLDAPGroup(getLDAPGroupMembers($ldapConn, $config->ParameterArray['LDAPBaseDN'], $config->ParameterArray['LDAPReadAccess']), $ldapUserGroups)) {
-		$person->ReadAccess = true;
-	}
-
-	if (inLDAPGroup(getLDAPGroupMembers($ldapConn, $config->ParameterArray['LDAPBaseDN'], $config->ParameterArray['LDAPWriteAccess']), $ldapUserGroups)) {
-		$person->WriteAccess = true;
-	}
-
-	if (inLDAPGroup(getLDAPGroupMembers($ldapConn, $config->ParameterArray['LDAPBaseDN'], $config->ParameterArray['LDAPDeleteAccess']), $ldapUserGroups)) {
-		$person->DeleteAccess = true;
-	}
-
-	if (inLDAPGroup(getLDAPGroupMembers($ldapConn, $config->ParameterArray['LDAPBaseDN'], $config->ParameterArray['LDAPAdminOwnDevices']), $ldapUserGroups)) {
-		$person->AdminOwnDevices = true;
-	}
-
-	if (inLDAPGroup(getLDAPGroupMembers($ldapConn, $config->ParameterArray['LDAPBaseDN'], $config->ParameterArray['LDAPRackRequest']), $ldapUserGroups)) {
-		$person->RackRequest = true;
-	}
-
-	if (inLDAPGroup(getLDAPGroupMembers($ldapConn, $config->ParameterArray['LDAPBaseDN'], $config->ParameterArray['LDAPRackAdmin']), $ldapUserGroups)) {
-		$person->RackAdmin = true;
-	}
-
-	if (inLDAPGroup(getLDAPGroupMembers($ldapConn, $config->ParameterArray['LDAPBaseDN'], $config->ParameterArray['LDAPContactAdmin']), $ldapUserGroups)) {
-		$person->ContactAdmin = true;
-	}
-
-	if (inLDAPGroup(getLDAPGroupMembers($ldapConn, $config->ParameterArray['LDAPBaseDN'], $config->ParameterArray['LDAPBulkOperations']), $ldapUserGroups)) {
-		$person->BulkOperations = true;
-	}
-
-	if (inLDAPGroup(getLDAPGroupMembers($ldapConn, $config->ParameterArray['LDAPBaseDN'], $config->ParameterArray['LDAPSiteAdmin']), $ldapUserGroups)) {
-		$person->SiteAdmin = true;
-	}
-
-        if ( isset($_SESSION['userid']) ) {
-          if ( $person->PersonID > 0 ) {
-            $person->UpdatePerson();
-          } else {
-            $person->CreatePerson();
-          }
-          if ( isset($_COOKIE['targeturl'] )) {
-            header('Location: ' . html_entity_decode($_COOKIE['targeturl']));
-          } else {
-            header('Location: ' . redirect('index.php'));
-          }
-          exit;
-        } else {
-          $content .= "<h3>Login failed.  Incorrect username, password, or rights.</h3>";
-        }
-
-      }
+  function doLogout() {
+    global $content;
+    if (!isset($_GET['logout'])) {
+      return;
     }
 
+    session_unset();
+    $_SESSION = array();
+    unset($_SESSION['userid']);
+    session_destroy();
+    session_commit();
+    $content = '<h3>Logout successful.</h3>';
   }
 
+  function connectLDAP()
+  {
+    global $ldapConn, $content, $config;
+    if ($ldapConn) {
+      return $ldapConn;
+    }
 
+    $ldapServer = $config->ParameterArray['LDAPServer'];
+    $ldapConn = ldap_connect($ldapServer);
+    if (! $ldapConn ) {
+      $content = '<h3>Fatal error.  The LDAP server is not reachable.  Please try again later, or contact your system administrator to check the configuration.</h3>';
+      error_log('Unable to connect to LDAP Server: ' . $ldapServer);
+      return false;
+    }
+    ldap_set_option($ldapConn, LDAP_OPT_PROTOCOL_VERSION, 3);
+    ldap_set_option($ldapConn, LDAP_OPT_REFERRALS, 0);
+
+    return $ldapConn;
+  }
+
+  function bindLDAP($username = NULL, $password = NULL) {
+    global $ldapConn, $config;
+    if (! connectLDAP()) {
+      return;
+    }
+
+    if (! $username)
+    {
+      $username = $config->ParameterArray['LDAPBindDN'];
+      $password = $config->ParameterArray['LDAPBindPassword'];
+    }
+
+    return ldap_bind($ldapConn, $username, $password);
+  }
+
+  function expandString($info, $macro)
+  {
+    $macro = html_entity_decode($macro);
+    foreach(array_keys($info) as $key) {
+      $macro = str_replace('%'. $key . '%', $info[$key], $macro);
+    }
+    return $macro;
+  }
+
+  function findUserDN($username) {
+    global $ldapConn, $content, $config;
+    $bind = bindLDAP();
+    if (! $bind) {
+      $content = '<h3>Fatal error.  The LDAP server is not reachable.  Please try again later, or contact your system administrator to check the configuration.</h3>';
+      error_log('Unable to bind to LDAP Server using: ' . $config->ParameterArray['LDAPBindDN']);
+      return false;
+    }
+    $searchFilter = expandString(['userid' => $username], $config->ParameterArray['LDAPUserSearch']);
+    $search = ldap_search($ldapConn,
+      $config->ParameterArray['LDAPBaseDN'],
+      $searchFilter,
+      ['givenName', 'sn', 'mail', 'sAMAccountName']);
+    if (! $search) {
+      ldap_get_option($ldapConn, LDAP_OPT_DIAGNOSTIC_MESSAGE, $extended_info);
+      error_log("LDAP DIAGNOSTIC: " . $extended_info);
+      return false;
+    }
+    $results = ldap_get_entries($ldapConn, $search);
+    return $results;
+  }
+
+  function searchGroups($userDN) {
+    global $ldapConn, $config;
+    $searchFilter = expandString($userDN, $config->ParameterArray['LDAPBaseSearch']);
+    $search = ldap_search($ldapConn,
+      $config->ParameterArray['LDAPBaseDN'],
+      $searchFilter,
+      ['dn']);
+    return ldap_get_entries($ldapConn, $search);
+  }
+
+  function refreshRights($userDN) {
+    global $person, $config;
+    $person->UserID = $userDN['samaccountname'];
+    $person->GetPersonByUserID();
+    $person->revokeAll();
+
+    $groups = searchGroups($userDN);
+    $isAuth = false;
+
+    for ($i = 0; $i < $groups['count']; $i++) {
+      if ($config->ParameterArray['LDAPSiteAccess'] == "" || ($groups[$i]['dn'] == $config->ParameterArray['LDAPSiteAccess']) ) {
+        $_SESSION['userid'] = $userDN['samaccountname'];
+        $_SESSION['LoginTime'] = time();
+        session_commit();
+        $isAuth = true;
+      }
+
+      if ($groups[$i]['dn'] == $config->ParameterArray['LDAPReadAccess']) {
+        $person->ReadAccess = true;
+      }
+      if ($groups[$i]['dn'] == $config->ParameterArray['LDAPWriteAccess']) {
+        $person->WriteAccess = true;
+      }
+      if ($groups[$i]['dn'] == $config->ParameterArray['LDAPDeleteAccess']) {
+        $person->DeleteAccess = true;
+      }
+      if ($groups[$i]['dn'] == $config->ParameterArray['LDAPAdminOwnDevices']) {
+        $person->AdminOwnDevices = true;
+      }
+      if ($groups[$i]['dn'] == $config->ParameterArray['LDAPRackRequest']) {
+        $person->RackRequest = true;
+      }
+      if ($groups[$i]['dn'] == $config->ParameterArray['LDAPRackAdmin']) {
+        $person->RackAdmin = true;
+      }
+      if ($groups[$i]['dn'] == $config->ParameterArray['LDAPContactAdmin']) {
+        $person->ContactAdmin = true;
+      }
+      if ($groups[$i]['dn'] == $config->ParameterArray['LDAPBulkOperations']) {
+        $person->BulkOperations = true;
+      }
+      if ($groups[$i]['dn'] == $config->ParameterArray['LDAPSiteAdmin']) {
+        $person->SiteAdmin = true;
+      }
+    }
+    return $isAuth;
+  }
+
+  function doLogin() {
+    global $person, $content, $loginFailedMsg;
+    if (!isset($_POST['username'])) {
+      return;
+    }
+    $username = htmlspecialchars($_POST['username']);
+    $password = $_POST['password'];
+    $userDN = findUserDN($username);
+    if (! $userDN) {
+      return false;
+    } else if ($userDN['count'] < 1) {
+      error_log("User search failed\n");
+      $content = $loginFailedMsg;
+      return false;
+    }
+    $userDN = $userDN[0];
+    $userInfo = array('dn' => $userDN['dn'],
+                      'userdn' => $userDN['dn'],
+                      'sn' => @$userDN['sn'][0],
+                      'givenName' => @$userDN['givenname'][0],
+                      'mail' => @$userDN['mail'][0],
+                      'userid' => $userDN['samaccountname'][0],
+                      'samaccountname' => $userDN['samaccountname'][0],
+                    );
+
+    $ldapBind = bindLDAP($userInfo['dn'], $password);
+
+    if (! $ldapBind) {
+      error_log("Bind as User failed");
+      $content = $loginFailedMsg;
+      return false;
+    }
+
+    if (refreshRights($userInfo)) {
+      $person->FirstName = @$userInfo['givenName'];
+      $person->LastName = @$userInfo['sn'];
+      $person->Email = @$userInfo['mail'];
+
+      if ($person->PersonID > 0) {
+        $person->UpdatePerson();
+      } else {
+        $person->CreatePerson();
+      }
+
+      if (isset($_COOKIE['targeturl'])) {
+        error_log('Cookie Target: ' . $_COOKIE['targeturl']);
+        header('Location: ' . html_entity_decode($_COOKIE['targeturl']));
+      } else {
+        header('Location: ' . redirect('index.php'));
+      }
+      exit;
+    } else {
+      error_log("Not authorized");
+      $content = $loginFailedMsg;
+    }
+  }
+  doLogout();
+  doLogin();
 ?>
 <!doctype html>
 <html>
 <head>
   <meta http-equiv="X-UA-Compatible" content="IE=Edge">
   <meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
-  
+
   <title>openDCIM Data Center Inventory</title>
   <link rel="stylesheet" href="css/inventory.php" type="text/css">
   <link rel="stylesheet" href="css/jquery-ui.css" type="text/css">
   <!--[if lt IE 9]>
   <link rel="stylesheet"  href="css/ie.css" type="text/css" />
   <![endif]-->
-  
+
   <script type="text/javascript" src="scripts/jquery.min.js"></script>
   <script type="text/javascript" src="scripts/jquery-ui.min.js"></script>
 <script type="text/javascript">
@@ -215,7 +238,7 @@ $(document).ready(function() {
 
 <?php echo $content; ?>
 
-<form action="login_ldap.php" method="post">
+<form action="login_ad.php" method="post">
 <div class="table">
   <div>
     <div><label for="username"><?php echo __("Username:"); ?></label></div>

--- a/misc.inc.php
+++ b/misc.inc.php
@@ -3,6 +3,12 @@
 
 /* Create a quick reference for datacenter data */
 $_SESSION['datacenters']=DataCenter::GetDCList(true);
+$AUTH_SCRIPT = '';
+if ( AUTHENTICATION == 'LDAP' ) {
+  $AUTH_SCRIPT = 'login_ldap.php';
+} else if ( AUTHENTICATION == 'AD' ) {
+  $AUTH_SCRIPT = 'login_ad.php';
+}
 
 /* Generic html sanitization routine */
 
@@ -12,7 +18,7 @@ if(!function_exists("sanitize")){
 		if ( is_null($string) ) {
 			$string = "";
 		}
-		
+
 		// Trim any leading or trailing whitespace
 		$clean=trim($string);
 
@@ -24,7 +30,7 @@ if(!function_exists("sanitize")){
 
 		// Strip out the shit we don't allow
 		$clean=strip_tags($clean, $allowedtags);
-		// If we decide to strip double quotes instead of encoding them uncomment the 
+		// If we decide to strip double quotes instead of encoding them uncomment the
 		//	next line
 	//	$clean=($stripall)?str_replace('"','',$clean):$clean;
 		// What is this gonna do ?
@@ -45,7 +51,7 @@ if (!function_exists('curl_file_create')) {
     }
 }
 
-/* 
+/*
 Regex to make sure a valid URL is in the config before offering options for contact lookups
 http://www.php.net/manual/en/function.preg-match.php#93824
 
@@ -60,7 +66,7 @@ function isValidURL($url){
 	$urlregex.="(\:[0-9]{2,5})?"; // Port
 	$urlregex.="(\/([a-z0-9+\$_-]\.?)+)*\/?"; // Path
 	$urlregex.="(\?[a-z+&\$_.-][a-z0-9;:@&%=+\/\$_.-]*)?"; // GET Query
-	$urlregex.="(#[a-z_.-][a-z0-9+\$_.-]*)?"; // Anchor 
+	$urlregex.="(#[a-z_.-][a-z0-9+\$_.-]*)?"; // Anchor
 // Testing out the php url validation, leaving the regex for now
 //	if(preg_match("/^$urlregex$/",$url)){return true;}
 	return filter_var($url, FILTER_VALIDATE_URL);
@@ -187,7 +193,7 @@ function sort2d ($array, $index){
 	//Rebuild original array using the newly sorted order.
 	foreach(array_keys($temp) as $key){$sorted[$key]=$array[$key];}
 	return $sorted;
-}  
+}
 /*
  * Sort multidimentional array in reverse order
  *
@@ -201,7 +207,7 @@ function arsort2d ($array, $index){
 	//Rebuild original array using the newly sorted order.
 	foreach(array_keys($temp) as $key){$sorted[$key]=$array[$key];}
 	return $sorted;
-}  
+}
 
 /*
  * Extend sql queries
@@ -724,7 +730,7 @@ if(!function_exists("buildNavTreeArray")){
 }
 
 // This will format the array above into the format needed for the side bar navigation
-// menu. 
+// menu.
 if(!function_exists("buildNavTreeHTML")){
 	function buildNavTreeHTML($menu=null){
 		$tl=1; //tree level
@@ -794,7 +800,7 @@ if(!function_exists("buildNavTreeHTML")){
 
 
 /*
-	Check if we are doing a new install or an upgrade has been applied.  
+	Check if we are doing a new install or an upgrade has been applied.
 	If found then force the user into only running that function.
 
 	To bypass the installer check from running, simply add
@@ -836,16 +842,16 @@ if( AUTHENTICATION=="Oauth" && !isset($_SESSION['userid']) && php_sapi_name()!="
 // Just to keep things from getting extremely wonky and complicated, even though this COULD be in one giant
 // if/then/else stanza, I'm breaking it into two
 
-if( AUTHENTICATION=="LDAP" && $config->ParameterArray["LDAPSessionExpiration"] > 0 && isset($_SESSION['userid']) && ((time() - $_SESSION['LoginTime']) > $config->ParameterArray['LDAPSessionExpiration'])) {
+if( (AUTHENTICATION=="LDAP" || AUTHENTICATION == "AD") && $config->ParameterArray["LDAPSessionExpiration"] > 0 && isset($_SESSION['userid']) && ((time() - $_SESSION['LoginTime']) > $config->ParameterArray['LDAPSessionExpiration'])) {
 	session_unset();
 	session_destroy();
 	session_start();
 }
 
-if( AUTHENTICATION=="LDAP" && !isset($_SESSION['userid']) && php_sapi_name()!="cli" && !isset($loginPage)) {
+if( (AUTHENTICATION=="LDAP" || AUTHENTICATION == "AD") && !isset($_SESSION['userid']) && php_sapi_name()!="cli" && !isset($loginPage)) {
 	$savedurl = $_SERVER['SCRIPT_NAME'] . "?" . $_SERVER['QUERY_STRING'];
 	setcookie( 'targeturl', $savedurl, time()+60 );
-	header("Location: ".redirect('login_ldap.php'));
+  header("Location: ".redirect($AUTH_SCRIPT));
 	exit;
 }
 
@@ -857,8 +863,8 @@ if(!People::Current()){
 	} elseif ( AUTHENTICATION=="Saml"){
 		header("Location: ".redirect('saml/login.php'));
 		exit;
-	} elseif ( AUTHENTICATION=="LDAP" && !isset($loginPage) ) {
-		header("Location: ".redirect('login_ldap.php'));
+	} elseif ( (AUTHENTICATION=="LDAP" || AUTHENTICATION=="AD") && !isset($loginPage) ) {
+		header("Location: ".redirect($AUTH_SCRIPT));
 		exit;
 	} elseif(AUTHENTICATION=="Apache"){
 		print "<h1>You must have some form of Authentication enabled to use openDCIM.</h1>";
@@ -880,10 +886,10 @@ if(($person->Disabled || ($person->PersonID==0 && $person->UserID!="cli_admin"))
 	exit;
 }
 
-/* 
+/*
  * This is an attempt to be sane about the rights management and the menu.
  * The menu will be built off a master array that is a merger of what options
- * the user has available.  
+ * the user has available.
  *
  * Array structure:
  * 	[]->Top Level Menu Item
@@ -938,12 +944,12 @@ if ( $person->SiteAdmin ) {
 	$samenu[__("Path Connections")][]='<a href="pathmaker.php"><span>'.__("Make Path Connection").'</span></a>';
 	$samenu[]='<a href="configuration.php"><span>'.__("Edit Configuration").'</span></a>';
 }
-if( AUTHENTICATION == "LDAP" ) {
+if((AUTHENTICATION=="LDAP" || AUTHENTICATION == "AD")) {
 	// Clear out the Reports menu button and create the Login menu button when not logged in
 	if ( isset($loginPage) ) {
 		$rmenu = array();
 	}
-	$lmenu[]='<a href="login_ldap.php?logout"><span>'.__("Logout").'</span></a>';
+	$lmenu[]='<a href="'.$AUTH_SCRIPT.'?logout"><span>'.__("Logout").'</span></a>';
 }
 
 function download_file($archivo, $downloadfilename = null) {
@@ -977,7 +983,7 @@ function download_file_from_string($string, $downloadfilename) {
 }
 
 /*
- * In an attempt to keep html generation out of the primary class definitions 
+ * In an attempt to keep html generation out of the primary class definitions
  * this function is being put here to make a quick convenient method of drawing
  * racks.  This will NOT put the devices in the rack.
  *


### PR DESCRIPTION
Some directories do not keep the username as part of the user's DN.
This makes it difficult or impossible to authenticate users who do
not follow this pattern, as many AD directories do not have userid
as part of the DN.  This patch will search for users given a
filter expression, and can bind to the directory using a bindDN and
BindPassword.

The new algorithm is:
1. Bind to `LDAPServer` using `LDAPBindDN` and `LDAPBindPassword`
2. Search for user in `LDAPBaseDN` using filter in `LDAPUserSearch`
  a. If nothing returned, fail login
3. Use `DN` of found user record and password from login form to bind to `LDAPServer`
  a. If bind fails, fail login
4. Check authorization by getting LDAP groups under `LDAPBaseDN` filtering using `LDAPBaseSearch`
  a. Added new macro expansion for _%userdn%_ in `LDAPBaseDN`
  b. Authorization check uses existing logic for checking groups.