### PR TITLE
Correct device status colour for 1/2 depth devices in cabinet view  

### DIFF
--- a/misc.inc.php
+++ b/misc.inc.php
@@ -1059,9 +1059,9 @@ function BuildCabinet($cabid,$face="front"){
 				}
 				$rowspan=abs($top)+abs($bottom);
 				$height=(((abs($top)+abs($bottom))*ceil(220*(1.75/19))))."px";
-				$htmlcab.="\t<tr id=\"pos$x\"><td class=\"pos$error\">$x</td><td rowspan=$rowspan><div id=\"servercontainer$rs\" class=\"freespace\" style=\"width: 220px; height: $height\" data-face=\"$face\"></div></td></tr>\n";
+				$htmlcab.="\t<tr id=\"pos$x\"><td class=\"pos$error pos-$face\">$x</td><td rowspan=$rowspan><div id=\"servercontainer$rs\" class=\"freespace\" style=\"width: 220px; height: $height\" data-face=\"$face\"></div></td></tr>\n";
 			}else{
-				$htmlcab.="\t<tr id=\"pos$x\"><td class=\"pos$error\">$x</td></tr>\n";
+				$htmlcab.="\t<tr id=\"pos$x\"><td class=\"pos$error pos-$face\">$x</td></tr>\n";
 			}
 		}
 	}

--- a/preflight.inc.php
+++ b/preflight.inc.php
@@ -101,7 +101,7 @@
 				$tests['db.inc']['message']="db.inc.php has been detected and in the proper place";
 				require_once("db.inc.php");
 				// check for strict_trans_tables
-				if(strpos(@end($dbh->query("select @@global.sql_mode;")->fetch()),'STRICT_TRANS_TABLES') === false){
+				if(strpos(@end($dbh->query("select @@session.sql_mode;")->fetch()),'STRICT_TRANS_TABLES') === false){
 					$tests['strictdb']['state']="good";
 					$tests['strictdb']['message']='';
 				}else{

--- a/scripts/common.js
+++ b/scripts/common.js
@@ -1598,7 +1598,15 @@ function InsertDevice(obj){
 
 		for(var i=0;obj.Height-1>=i;i++){
 			var stName=obj.Status.split(' ').join('_');
-			StartingU.find('.pos').addClass(stName);
+			var faceClass='.pos';
+			if(obj.HalfDepth==1) {
+				if(obj.BackSide==0) {
+					faceClass='.pos-front';
+				} else {
+					faceClass='.pos-rear';
+				}
+			} 
+			StartingU.find($faceClass).addClass(stName);
 			$('#legend > .legenditem > span.'+stName).parent('div').removeClass('hide');
 			StartingU.find('.pos').addClass('dept'+obj.Owner);
 			StartingU=StartingU.prev(); // move our pointer up a u

--- a/scripts/common.js
+++ b/scripts/common.js
@@ -1606,7 +1606,7 @@ function InsertDevice(obj){
 					faceClass='.pos-rear';
 				}
 			} 
-			StartingU.find($faceClass).addClass(stName);
+			StartingU.find(faceClass).addClass(stName);
 			$('#legend > .legenditem > span.'+stName).parent('div').removeClass('hide');
 			StartingU.find('.pos').addClass('dept'+obj.Owner);
 			StartingU=StartingU.prev(); // move our pointer up a u


### PR DESCRIPTION
uses @valffadir preflight check db fix as commented in #457
 
Colour styling on 1/2 depth devices in the cabinet view were bleeding into both front and rear views. This fix adds a `pos-front` and `pos-rear` class to the cabinet view device `<td>` element and only applies status styling to the correct cabinet face.