### PR TITLE
Fixing rights for user administration

### DIFF
--- a/usermgr.php
+++ b/usermgr.php
@@ -4,7 +4,7 @@
 
 	$subheader=__("Data Center Contact Detail");
 
-	if(!$person->SiteAdmin){
+	if(!$person->SiteAdmin || !$person->ContactAdmin){
 		header('Location: '.redirect());
 		exit;
 	}


### PR DESCRIPTION
It seems more logical like this, considering we can't see the "User Administration" button without "ContactAdmin" access.