### PR TITLE
Enhanced ldap integration

### DIFF
--- a/login_ldap.php
+++ b/login_ldap.php
@@ -82,7 +82,7 @@ if(!function_exists("ldap_escape")){
 
         // These are standard schema items, so they aren't configurable
         // However, suppress any errors that may crop up from not finding them
- 	 $found_dn = @$ldapResults[0]['cn'][0];
+	$found_dn = @$ldapResults[0]['cn'][0];
         $person->FirstName = @$ldapResults[0]['givenname'][0];
         $person->LastName = @$ldapResults[0]['sn'][0];
         $person->Email = @$ldapResults[0]['mail'][0];

--- a/login_ldap.php
+++ b/login_ldap.php
@@ -154,21 +154,6 @@ if(!function_exists("ldap_escape")){
           }
         }
 
-        // Now get some more info about the user
-        // Insert the default 4.2 UserSearch string in case this is an upgrade instance
-        if ( ! isset($config->ParameterArray['LDAPUserSearch'])) {
-          $config->ParameterArray['LDAPUserSearch'] = "(|(uid=%userid%))";
-        }
-        $userSearch = str_replace( "%userid%", $ldapUser, html_entity_decode($config->ParameterArray['LDAPUserSearch']));
-        $ldapSearch = ldap_search( $ldapConn, $config->ParameterArray['LDAPBaseDN'], $userSearch );
-        $ldapResults = ldap_get_entries( $ldapConn, $ldapSearch );
-
-        // These are standard schema items, so they aren't configurable
-        // However, suppress any errors that may crop up from not finding them
-        $person->FirstName = @$ldapResults[0]['givenname'][0];
-        $person->LastName = @$ldapResults[0]['sn'][0];
-        $person->Email = @$ldapResults[0]['mail'][0];
-
         if ( isset($_SESSION['userid']) ) {
           if ( $person->PersonID > 0 ) {
             $person->UpdatePerson();

--- a/login_ldap.php
+++ b/login_ldap.php
@@ -1,5 +1,30 @@
 <?php
 
+
+if(!function_exists("ldap_escape")){
+	function ldap_escape($str = '') {
+		$metaChars = array(
+			chr(0x5c), // \
+			chr(0x2a), // *
+			chr(0x28), // (
+			chr(0x29), // )
+			chr(0x00) // NUL
+		);
+
+		// Build the list of the escaped versions of those characters.
+		$quotedMetaChars = array ();
+		foreach ($metaChars as $key => $value) {
+			$quotedMetaChars[$key] = '\\' .
+			str_pad(dechex(ord($value)), 2, '0', STR_PAD_LEFT);
+		}
+
+		// Make all the necessary replacements in the input string and return
+		// the result.
+		return str_replace($metaChars, $quotedMetaChars, $str);
+	}
+}
+
+
   // Set a variable so that misc.inc.php knows not to throw us into an infinite redirect loop
   $loginPage = true;
 
@@ -30,9 +55,9 @@
       ldap_set_option( $ldapConn, LDAP_OPT_PROTOCOL_VERSION, 3 );
       ldap_set_option( $ldapConn, LDAP_OPT_REFERRALS, 0 );
 
-      $ldapUser = htmlspecialchars($_POST['username']);
+      $ldapUser = ldap_escape(htmlspecialchars($_POST['username']));
       $ldapDN = str_replace( "%userid%", $ldapUser, $config->ParameterArray['LDAPBindDN']);
-      $ldapPassword = $_POST['password'];
+      $ldapPassword = ldap_escape($_POST['password']);
 
       $ldapBind = ldap_bind( $ldapConn, $ldapDN, $ldapPassword );
 

--- a/login_ldap.php
+++ b/login_ldap.php
@@ -107,7 +107,7 @@ if(!function_exists("ldap_escape")){
           //
           // So, here we are with a ton of if/then statements.
 
-          if ( $config->ParameterArray['LDAPSiteAccess'] == "" || $ldapResults[$i]['dn'] == $config->ParameterArray['LDAPSiteAccess'] ) {
+          if ( $config->ParameterArray['LDAPSiteAccess'] == "" || !strcasecmp($ldapResults[$i]['dn'], $config->ParameterArray['LDAPSiteAccess']) ) {
             // No specific group membership required to access openDCIM or they have a match to the group required
             $_SESSION['userid'] = $ldapUser;
             $_SESSION['LoginTime'] = time();
@@ -117,39 +117,39 @@ if(!function_exists("ldap_escape")){
             error_log( __("LDAP authentication successful, but access denied based on lacking group membership.  Username:") . $ldapUser);
           }
 
-          if ( $ldapResults[$i]['dn'] == $config->ParameterArray['LDAPReadAccess'] ) {
+          if ( !strcasecmp($ldapResults[$i]['dn'],$config->ParameterArray['LDAPReadAccess'])) {
               $person->ReadAccess = true;
           }
           
-          if ( $ldapResults[$i]['dn'] == $config->ParameterArray['LDAPWriteAccess'] ) {
+          if ( !strcasecmp($ldapResults[$i]['dn'], $config->ParameterArray['LDAPWriteAccess'] )) {
               $person->WriteAccess = true;
           }
 
-          if ( $ldapResults[$i]['dn'] == $config->ParameterArray['LDAPDeleteAccess'] ) {
+          if ( !strcasecmp($ldapResults[$i]['dn'], $config->ParameterArray['LDAPDeleteAccess'] )) {
               $person->DeleteAccess = true;
           }
           
-          if ( $ldapResults[$i]['dn'] == $config->ParameterArray['LDAPAdminOwnDevices'] ) {
+          if ( !strcasecmp($ldapResults[$i]['dn'], $config->ParameterArray['LDAPAdminOwnDevices'] )) {
               $person->AdminOwnDevices = true;
           }
           
-          if ( $ldapResults[$i]['dn'] == $config->ParameterArray['LDAPRackRequest'] ) {
+          if ( !strcasecmp($ldapResults[$i]['dn'], $config->ParameterArray['LDAPRackRequest'] )) {
               $person->RackRequest = true;
           }
           
-          if ( $ldapResults[$i]['dn'] == $config->ParameterArray['LDAPRackAdmin'] ) {
+          if ( !strcasecmp($ldapResults[$i]['dn'], $config->ParameterArray['LDAPRackAdmin'] )) {
               $person->RackAdmin = true;
           }
           
-          if ( $ldapResults[$i]['dn'] == $config->ParameterArray['LDAPContactAdmin'] ) {
+          if ( !strcasecmp($ldapResults[$i]['dn'], $config->ParameterArray['LDAPContactAdmin'] )) {
               $person->ContactAdmin = true;
           }
           
-          if ( $ldapResults[$i]['dn'] == $config->ParameterArray['LDAPBulkOperations'] ) {
+          if ( !strcasecmp($ldapResults[$i]['dn'], $config->ParameterArray['LDAPBulkOperations'] )) {
               $person->BulkOperations = true;
           }
 
-          if ( $ldapResults[$i]['dn'] == $config->ParameterArray['LDAPSiteAdmin'] ) {
+          if ( !strcasecmp($ldapResults[$i]['dn'], $config->ParameterArray['LDAPSiteAdmin'] )) {
               $person->SiteAdmin = true;
           }
         }


### PR DESCRIPTION
LDAP integration for SAMBA 4.5 as a domain controller running on Debian 9.

opendcim LDAP config:

Base DN: dc=domain,dc=tld
Base Search: (&(objectClass=group)(member:1.2.840.113556.1.4.1941:=CN=%userid%,CN=Users,DC=domain,DC=tld))

This is LDAP_MATCHING_RULE_IN_CHAIN so you can grant access to opendcim for groups containing final users. For easier user management. Supported since samba 4.5.


Bind DN: YOURDOMAIN\%userid%

User Search: (|(sAMAccountName=%userid%))

SiteAccess: cn=DCIM_SiteAccess,ou=SW_permissions,dc=domain,dc=tld

Where SW_permissions is OU and DCIM_SiteAccess is group granting access to openDCIM.

Edit to your needs.

Tested on openDCIM 4.5 and samba 4.5.12 on Debian9
