### PR TITLE
Added support for SNMP data concentrating devices

### DIFF
--- a/classes/PowerDistribution.class.php
+++ b/classes/PowerDistribution.class.php
@@ -143,6 +143,29 @@ class PowerDistribution {
 		$caller=debug_backtrace();
 		$caller=$caller[1]['function'];
 
+
+        /*****************************************************************************************************
+         * BEGIN - Support for SNMP Data Concentrators
+         *****************************************************************************************************/
+        // If the OID path specifies a placeholder, then the device must "provide" a custom attribute's value for it
+        if (preg_match('/(?<placeholder>\{(?<tag>[^\}]+)+\})/i', $oid, $oid_matches))
+        {
+            // Look for numeric custom attribute that matches the pattern found on the oid path
+            if (isset($dev->{$oid_matches['tag']}) && is_numeric($dev->{$oid_matches['tag']}))
+            {
+                $oid = str_replace($oid_matches['placeholder'], $dev->{$oid_matches['tag']}, $oid);
+            }
+            else
+            {
+                error_log("PowerDistribution::$caller($dev->DeviceID) Inconsistent OID information for device '$dev->Label'. Cannot proceed with SNMP lookup.");
+                return false; // Do not increment failures in this case (configuration issue, not a failure to respond)
+            }
+        }
+        /*****************************************************************************************************
+         * END - Support for SNMP Data Concentrators
+         *****************************************************************************************************/
+
+        
 		$snmpHost=new OSS_SNMP\SNMP($dev->PrimaryIP,$dev->SNMPCommunity,$dev->SNMPVersion,$dev->v3SecurityLevel,$dev->v3AuthProtocol,$dev->v3AuthPassphrase,$dev->v3PrivProtocol,$dev->v3PrivPassphrase);
 		$snmpresult=false;
 		try {


### PR DESCRIPTION
This is to add support for SNMP data concentrators, such as http://datacentreservices4u.co.uk/shop/smart-monitoring-software/8-e3meter-data-concentrator.html

Because of SNMP data concentrators, to read a specific CDU's power usage value via SNMP, we cannot query that CDU directly (it is not even connected to the network itself) but we have to send our query to the SNMP data concentrator with a small parameter which is the CDU's identifier (an integer). The concentrator will then read it via powerline from the specified CDU and give the result back to us. 

For each CDU device we set: a) the IP address to one of our concentrators' ip and b) the ID of that CDU (which is saved as a custom attribute).

For each CDU template we change the OID paths to include a placeholder, which will be substituted with the CDU identifier at the moment of the SNMP lookup.

Example of device:
- Ip address: 10.5.2.115
- Custom attribute "meter_id" = 1234

Example of CDU template:
- Firmware Version OID = ".1.3.6.1.4.1.21695.1.10.3.1.5.{meter_id}"
- OID for Phase1 = ".1.3.6.1.4.1.21695.1.10.4.1.6.{meter_id}.0"
- OID for Phase2 = ".1.3.6.1.4.1.21695.1.10.4.1.6.{meter_id}.1"
- OID for Phase3 = ".1.3.6.1.4.1.21695.1.10.4.1.6.{meter_id}.2"

Under such example, when a SNMP lookup takes place the OID ".1.3.6.1.4.1.21695.1.10.4.1.6.{meter_id}.0" gets translated to ".1.3.6.1.4.1.21695.1.10.4.1.6.1234.0" before being executed.

This additional code only acts when an OID path contains a placeholder enclosed in curly braces (current proposed syntax). So it is fully compatible with configurations that does not involve data concentrators (hybrid situations are also not a problem).

Btw, I have made it so that if someone in another situation wants to take advantage of this change for things that do not have to do with "meters" (like CDUs are called by our concentrators), the label can be adapted freely. The {pattern} will just be searched on the available custom attributes, no matter than "tag" used.

PS: It's the first time I contribute to someone's project.