### PR TITLE
Update LogActions.class.php to fix truncation issue

### DIFF
--- a/classes/LogActions.class.php
+++ b/classes/LogActions.class.php
@@ -366,7 +366,7 @@ class LogActions {
 			}
 		}
 
-		$sql="SELECT DISTINCT CAST($sqlcolumn AS CHAR(20)) AS Search FROM fac_GenericLog WHERE $sqlcolumn!=\"\"$sqlextend ORDER BY $sqlcolumn ASC;";
+		$sql="SELECT DISTINCT CAST($sqlcolumn AS CHAR(80)) AS Search FROM fac_GenericLog WHERE $sqlcolumn!=\"\"$sqlextend ORDER BY $sqlcolumn ASC;";
 		$values=array();
 		foreach($this->query($sql) as $row){
 			$values[]=$row['Search'];


### PR DESCRIPTION
Up limit from 20 characters to 80 characters (matching change made in v3.1 where UserID column was changed from 20 to 80 characters). This resolves the issue I had with UserIDs being truncated when using the Actions Log.