### PR TITLE
Fix hardcoded path for SAML

### DIFF
--- a/saml/acs.php
+++ b/saml/acs.php
@@ -4,7 +4,7 @@ $loginPage = true;
 
 require_once('../db.inc.php');
 
-define("TOOLKIT_PATH", '/var/www/opendcim/vendor/onelogin/php-saml/');
+define("TOOLKIT_PATH", '../vendor/onelogin/php-saml/');
 require_once(TOOLKIT_PATH . '_toolkit_loader.php');
 
 require_once('settings.php');

--- a/saml/login.php
+++ b/saml/login.php
@@ -5,7 +5,7 @@ $loginPage = true;
 
 require_once('../db.inc.php');
 
-define("TOOLKIT_PATH", '/var/www/opendcim/vendor/onelogin/php-saml/');
+define("TOOLKIT_PATH", '../vendor/onelogin/php-saml/');
 require_once(TOOLKIT_PATH . '_toolkit_loader.php');
 
 require_once('settings.php');


### PR DESCRIPTION
Found a hardcoded path which breaks SAML authentication if openDCIM is not installed to /var/www/opendcim. e.g.:

[Mon Mar 12 12:36:53 2018] [error] [client xxxx] PHP Warning:  require_once(/var/www/opendcim/vendor/onelogin/php-saml/_toolkit_loader.php): failed to open stream: No such file or directory in /apps01/opendcim-test/saml/login.php on line 9
[Mon Mar 12 12:36:53 2018] [error] [client xxxx] PHP Fatal error:  require_once(): Failed opening required '/var/www/opendcim/vendor/onelogin/php-saml/_toolkit_loader.php' (include_path='.:/usr/share/pear:/usr/share/php') in /apps01/opendcim-test/saml/login.php on line 9
