### PR TITLE
Bulk device imports, HalfDepth and BackSide bug.

### DIFF
--- a/bulk_importer.php
+++ b/bulk_importer.php
@@ -414,8 +414,8 @@
       $dev->PrimaryIP = $row["Hostname"];
       $dev->SerialNo = $row["SerialNo"];
       $dev->AssetTag = $row["AssetTag"];
-      $dev->BackSide = in_array( strtoupper($row["BackSide"], $trueArray));
-      $dev->HalfDepth = in_array( strtoupper($row["HalfDepth"], $trueArray));
+      $dev->BackSide = in_array( strtoupper($row["BackSide"]), $trueArray);
+      $dev->HalfDepth = in_array( strtoupper($row["HalfDepth"]), $trueArray);
       $dev->Hypervisor = (in_array( $row["Hypervisor"], array( "ESX", "ProxMox")))?$row["Hypervisor"]:"None";
       if ( $row["InstallDate"] != "" ) {
         $dev->InstallDate = date( "Y-m-d", strtotime( $row["InstallDate"]));


### PR DESCRIPTION
I fixed a bug that was preventing HalfDepth and Backside fields from being set correctly when bulk importing devices.