### PR TITLE
PDO connection string modified for non default MySQL ports

### DIFF
--- a/db.inc.php-dist
+++ b/db.inc.php-dist
@@ -12,6 +12,7 @@
 	$devMode = false;
 
 	$dbhost = 'localhost';
+	$dbport = '3306';
 	$dbname = 'dcim';
 	$dbuser = 'dcim';
 	$dbpass = 'dcim';
@@ -25,7 +26,7 @@
 	);
 
 	try{
-			$pdoconnect="mysql:host=$dbhost;dbname=$dbname";
+			$pdoconnect="mysql:host=$dbhost;port=$dbport;dbname=$dbname";
 			$dbh=new PDO($pdoconnect,$dbuser,$dbpass,$pdo_options);
 	}catch(PDOException $e){
 			printf( "Error!  %s\n", $e->getMessage() );


### PR DESCRIPTION
In this commit PDO connection string is slighly modified to make it easier to
connect to MySQL DB instnaces that are running on non default ports.

Default out of the box MySQL servers listens to port 3306.
https://dev.mysql.com/doc/workbench/en/wb-mysql-connections-methods-standard.html

In this commit a new dbport vairable intoduced, dbport variable is initialized
with value 3306 so that OpenDCIM legacy behavior remains consistent, for the
setups where MySQL server is listening to a non default port user can use
desired port number instead.