### PR TITLE
Fix default buttons issue with selects on the configurations page

### DIFF
--- a/configuration.php
+++ b/configuration.php
@@ -448,7 +448,23 @@
 		$("#configtabs button").each(function(){
 			var a = $(this).parent().prev().find('input,select');
 			$(this).click(function(){
-				a.val($(this).parent().next().children('span').text());
+				
+				var value_to_set = $(this).parent().next().children('span').text();
+
+				// Only for selects, try to assign an existing option, so to avoid to default to an empty value that cannot be saved
+		                if (a.is("select"))
+                		{
+			        	a.find('option').each(function ()
+                    			{
+						if ($(this).val().toLowerCase() === value_to_set.toLowerCase())
+                        			{
+			                            value_to_set = $(this).val();
+                        			}
+                    			});
+                		}
+
+		                a.val(value_to_set);
+
 				if(a.hasClass('color-picker')){
 					a.minicolors('value', $(this).parent().next().children('span').text()).trigger('change');
 				}


### PR DESCRIPTION
Under the "Edit Configuration" page that the "<--" buttons do not work properly when there is a mismatch between the default value and the values available as options in the selects.

When the issue happens, the select gets focused on an inexistent empty option, which cannot be saved.

Example: when options available are "enabled" and "disabled", and the default value for a configuration is "Enabled" (different casing); then by clicking the "<--" button the problem is reproduced.