### PR TITLE
Fix rack requestor default value in new request form

### DIFF
--- a/rackrequest.php
+++ b/rackrequest.php
@@ -196,6 +196,13 @@
 		$contact->PersonID=$req->RequestorID;
 		$contact->GetPerson();
 	}
+
+	// When opening a new request, set the default value for the "Requestor" field's <select> to the logged in person
+	if (!isset($contact->UserID) && !isset($_POST["action"]))
+	{
+		$contact = $person;
+	}
+
 ?>
 <!doctype html>
 <html>


### PR DESCRIPTION
With this change, the rack request form shows the currently logged in user as default requestor. This does not affect the viewing of existing requests.

This is helpful to avoid requests being opened by mistake on behalf of the first person in the select; which is sorted alphabetically.