### PR TITLE
Changing cabinet labels from cabinet name to user preference based label controlled from edit configuration tab

### DIFF
--- a/classes/Cabinet.class.php
+++ b/classes/Cabinet.class.php
@@ -35,6 +35,7 @@ class Cabinet {
 	var $Location;
 	var $LocationSortable;
 	var $AssignedTo;
+	var $ShowCabinetLabel;
 	var $ZoneID;
 	var $CabRowID;      //JMGA: Row of this cabinet
 	var $CabinetHeight;
@@ -107,6 +108,18 @@ class Cabinet {
 		$cab->FrontEdge=$dbRow["FrontEdge"];
 		$cab->Notes=$dbRow["Notes"];
 		$cab->U1Position=$dbRow["U1Position"];
+		
+	    global $config;
+	    if($config->ParameterArray["AssignCabinetLabels"]=="OwnerName"){
+	    $dep->DeptID=$dbRow["AssignedTo"];
+	    $dep->GetDeptByID();
+	    $cab->ShowCabinetLabel=$dep->Name;}
+
+	    if($config->ParameterArray["AssignCabinetLabels"]=="KeyLockInformation"){
+	       $cab->ShowCabinetLabel=$dbRow["Keylock"]; }
+
+	    if($config->ParameterArray["AssignCabinetLabels"]=="ModelNo"){
+	       $cab->ShowCabinetLabel=$dbRow["Model"];  }
 
 		if($filterrights){
 			$cab->FilterRights();

--- a/configuration.php
+++ b/configuration.php
@@ -1940,6 +1940,17 @@ echo '<div class="main">
 						</select>
 					</div>
 				</div>
+                                 <div>
+					<div><label for="AssignCabinetLabels">',__("Which Cabinet Label?"),'</label></div>
+					<div><select id="AssignCabinetLabels" name="AssignCabinetLabels" defaultvalue="',$config->defaults["AssignCabinetLabels"],'" data="',$config->ParameterArray["AssignCabinetLabels"],'">
+
+							<option value="OwnerName">',__("Owner Name"),'</option>
+							<option value="KeyLockInformation">',__("Key Lock Information"),'</option>
+							<option value="ModelNo">',__("Model No"),'</option> 
+						</select>
+					</div>
+				</div>
+				
 			</div> <!-- end table -->
 			<h3>',__("Site"),'</h3>
 			<div class="table">

--- a/scripts/common.js
+++ b/scripts/common.js
@@ -1012,7 +1012,7 @@ function startmap(){
 			var row=false;
 			obj.ZoneID=0;
 		} else {
-			var label=obj.Location;
+			var label=obj.ShowCabinetLabel;
 			var name='cab'+obj.CabinetID;
 			var href='cabnavigator.php?cabinetid='+obj.CabinetID;
 			var row=obj.CabRowID==0?false:true;


### PR DESCRIPTION
![selection_031](https://user-images.githubusercontent.com/9385832/46561896-dfd9dc00-c8b6-11e8-9e28-3804795f5626.png)

The above image shows an extra feature added: A dropdown box below "Add Cabinet Labels", which is "Which Cabinet Label?". This helps in showing Cabinet labels according to user preference. 

For this feature to show up these commands need to be executed in mysql console:
mysql>use dcim;
mysql> INSERT INTO fac_Config
-> VALUES('AssignCabinetLabels','OwnerName','Name','string','OwnerName');