### PR TITLE
Fix for cabinet name missing on search results

### DIFF
--- a/search.php
+++ b/search.php
@@ -148,7 +148,7 @@
 			$temp[$x]['cabinet']=$device->Cabinet;
 			$temp[$x]['parent']=$device->ParentDevice;
 			$temp[$x]['rights']=$device->Rights;
-			$cabtemp[$device->Cabinet]="";
+			$cabtemp[$device->Cabinet] = [];
 			++$x;
 			if($device->ParentDevice>0){
 				foreach($uncleDaddy=$device->GetDeviceLineage() as $branches){


### PR DESCRIPTION
This pull request is meant to solve a little problem with search results (ref. to images). Initially we were shown the DataCenterID (2 in our case) stored in fac_Cabinet for the cabinets found.

We found this issue also in 4.3.1, but it might be due to how new php (7.1 in our case) manages array elements assignments.

Before:
<img width="269" alt="before" src="https://user-images.githubusercontent.com/35555794/47143343-35ee4c80-d2c5-11e8-9c4b-f1c7d1afb572.png">

After:
<img width="301" alt="after" src="https://user-images.githubusercontent.com/35555794/47143341-35ee4c80-d2c5-11e8-8a15-28995f7eaf3e.png">

