### PR TITLE
Add attribute 'uid' searching for group membership. Fixes #1114

### DIFF
--- a/login_ldap.php
+++ b/login_ldap.php
@@ -143,11 +143,22 @@
 
 				// These are standard schema items, so they aren't configurable
 				// However, suppress any errors that may crop up from not finding them
+                                $found_uid=@$ldapResults[0]['uid'][0];
 				$found_dn=@$ldapResults[0]['cn'][0];
 
 				$ldapSearchDN=str_replace("%userid%",$found_dn,html_entity_decode($config->ParameterArray['LDAPBaseSearch']));
 				$ldapSearch=ldap_search($ldapConn,$config->ParameterArray['LDAPBaseDN'],$ldapSearchDN);
 				$ldapResults=ldap_get_entries($ldapConn,$ldapSearch);
+
+                                //
+                                // RFC2307/posixAccount Groups are based on 'uid' attribute, not 'cn' attribute.
+                                // so if 'cn' returns nothing, try the 'uid' attribute.
+                                //
+                                if (!$ldapResults['count']){
+                                    $ldapSearchDN=str_replace("%userid%",$found_uid,html_entity_decode($config->ParameterArray['LDAPBaseSearch']));
+                                    $ldapSearch=ldap_search($ldapConn,$config->ParameterArray['LDAPBaseDN'],$ldapSearchDN);
+                                    $ldapResults=ldap_get_entries($ldapConn,$ldapSearch);
+                                }
 
 				// Because we have audit logs to maintain, we need to make a local copy of the User's record
 				// to keep in the openDCIM database just in case the user gets removed from LDAP.  This also


### PR DESCRIPTION
Add attribute 'uid' searching for group membership.  Current code assumes active directory
style ldap group tree; this adds searching for RFC2307 style schemas in the tree.

totally transparent to the end user, as long as Base Search is set to the proper value ie, the hint is is '(&(objectClass=posixGroup)(memberUid=%userid%))'