### PR TITLE
Tooltip escalations/escalationTime sql fix

### DIFF
--- a/classes/EscalationTimes.class.php
+++ b/classes/EscalationTimes.class.php
@@ -74,7 +74,9 @@ class EscalationTimes {
         function GetEscalationTime(){
                 $sql="SELECT * FROM fac_EscalationTimes WHERE EscalationTimeID=$this->EscalationTimeID;";
 
-                if($row=$this->query($sql)->fetch()){
+                //if($row=$this->query($sql)->fetch()){
+                if($q=$this->query($sql)){
+                        $row=$q->fetch();
                         $this->EscalationTimeID=$row["EscalationTimeID"];
                         $this->TimePeriod=$row["TimePeriod"];
                         $this->MakeDisplay();

--- a/classes/Escalations.class.php
+++ b/classes/Escalations.class.php
@@ -75,7 +75,9 @@ class Escalations {
 
 		$sql="SELECT * FROM fac_Escalations WHERE EscalationID=$this->EscalationID;";
 		
-		if($row=$this->query($sql)->fetch()){
+		// if($row=$this->query($sql)->fetch()){
+                if($q=$this->query($sql)){
+                        $row=$q->fetch();
 			$this->EscalationID=$row["EscalationID"];
 			$this->Details=$row["Details"];
 			$this->MakeDisplay();


### PR DESCRIPTION
If you have no Escalations/escalationTimes on a object (pdu, device, etc), you'll get this error:

```
[Wed Jan 02 15:13:31.692594 2019] [php7:error] [pid 10315] [client 192.168.87.8:38156] PHP Fatal error:  Uncaught Error: Call to a member function fetch() on bool in /var/www/openDCIM/classes/EscalationTimes.class.php:77\nStack trace:\n#0 /var/www/openDCIM/scripts/ajax_tooltip.php(234): EscalationTimes->GetEscalationTime()\n#1 {main}\n  thrown in /var/www/openDCIM/classes/EscalationTimes.class.php on line 77, referer: https://opendcim-dev.nersc.gov/cabnavigator.php?cabinetid=46
```

This is because $this->query returns either an array, or an bool.  The bool returned is false when the sql statement fails (ie, you passed in a no valid EscalationIID) - and ->fetch() only works against arrays.

So splitting up this if statement fixes the problem.
