### PR TITLE
Power ports notes in the device template are not saved.

### DIFF
--- a/device_templates.php
+++ b/device_templates.php
@@ -147,7 +147,7 @@
 				$tport->TemplateID=$template->TemplateID;
 				$tport->PortNumber=$i;
 				$tport->Label=isset($_POST["powerlabel".$i])?$_POST["powerlabel".$i]:"";
-				$tport->Notes=isset($_POST["powerportnotes".$i])?$_POST["powerportnotes".$i]:"";
+				$tport->PortNotes=isset($_POST["powerportnotes".$i])?$_POST["powerportnotes".$i]:"";
 				$status=($tport->CreatePort())?$status:__("Error updating template power connections");
 			}
 			return $status;


### PR DESCRIPTION
An annoying typo because of which power ports notes in the device template are not saved :-(.