### PR TITLE
Saml validate response is related to the request

### DIFF
--- a/saml/acs.php
+++ b/saml/acs.php
@@ -28,7 +28,13 @@ if (!$auth->isAuthenticated()) {
 	exit();
 }
 
-if ($samlResponse->isValid()) {
+// Get and clear the SAML authRequest ID to validate the response is related
+if (isset($_SESSION['saml_req_id'])) {
+        $saml_reqID = $_SESSION['saml_req_id'];
+        $_SESSION['saml_req_id'] = '';
+}
+
+if ($samlResponse->isValid($saml_reqID)) {
 	$check_username = $samlResponse->getNameId();
 	$attributes = $samlResponse->getAttributes();
 	if (!empty($attributes)) {

--- a/saml/acs.php
+++ b/saml/acs.php
@@ -31,7 +31,7 @@ if (!$auth->isAuthenticated()) {
 // Get and clear the SAML authRequest ID to validate the response is related
 if (isset($_SESSION['saml_req_id'])) {
 	$saml_reqID = $_SESSION['saml_req_id'];
-	unset($_SESSION["saml_req_id"]);
+	unset($_SESSION['saml_req_id']);
 }
 
 if ($samlResponse->isValid($saml_reqID)) {

--- a/saml/acs.php
+++ b/saml/acs.php
@@ -30,8 +30,8 @@ if (!$auth->isAuthenticated()) {
 
 // Get and clear the SAML authRequest ID to validate the response is related
 if (isset($_SESSION['saml_req_id'])) {
-        $saml_reqID = $_SESSION['saml_req_id'];
-        $_SESSION['saml_req_id'] = '';
+	$saml_reqID = $_SESSION['saml_req_id'];
+	unset($_SESSION["saml_req_id"]);
 }
 
 if ($samlResponse->isValid($saml_reqID)) {

--- a/saml/login.php
+++ b/saml/login.php
@@ -18,6 +18,9 @@ if (!isset($_SESSION['samlUserdata'])) {
 	$settings = new OneLogin_Saml2_Settings($saml_settings);
 	$authRequest = new OneLogin_Saml2_AuthnRequest($settings);
 	$samlRequest = $authRequest->getRequest();
+
+	// Track the authRequest ID so the response can be validated
+	$_SESSION['saml_req_id'] = $authRequest->getID();
 	
 	$parameters = array('SAMLRequest' => $samlRequest);
 	$parameters['RelayState'] = OneLogin_Saml2_Utils::getSelfURLNoQuery();


### PR DESCRIPTION
SAML2 AuthnRequest ID is returned in the response from the Identity Provider as InResponseTo.  When validating the SAML response the application (openDCIM in this case) can pass the request ID to isValid().  The library compares it to the InResponseTo and if does not match the authentication attempt fails.  

Even the OneLogin sampes do not implement this but is is suggested to ensure that the response POSTED to the login was related to a request.

Temporarily using the _SESSION to store the value seems like the best approach to track the value between the initial login redirect and the post back