### PR TITLE
Possibly fixes the "empty property" error messages we saw

### DIFF
--- a/search.php
+++ b/search.php
@@ -127,9 +127,11 @@
 		$attrList=DeviceCustomAttribute::GetDeviceCustomAttributeList();
 		foreach($attrList as $ca){
 			$prop = $ca->Label;
-			$dev->$prop=(isset($_GET[$prop]))?$_GET[$prop]:$dev->$prop;
+			if(!empty($prop)){
+				$dev->$prop=(isset($_GET[$prop]))?$_GET[$prop]:$dev->$prop;
+			}
 		}
-		
+
 		if ( isset( $_GET["loose"] )) {
 			$devList = $dev->LooseSearch(true);
 		} else {


### PR DESCRIPTION
    As detailed on the mailing list, we saw an error when clicking
     on the "Number of Devices Using This Template" link from the
     Device Tepmplates page, suggesting an 'empty property"
    This patch merely checks for an 'empty property".