### PR TITLE
Function redirect: don't add an URL

### DIFF
--- a/misc.inc.php
+++ b/misc.inc.php
@@ -143,12 +143,8 @@ function redirect($target = null) {
 		// $installURL isn't blank so combine it with the target to get a valid redirect target
 		$url = $installURL.$target;
 	}else{
-		// $installURL is blank so let's try to guess what the server will be for the redirect
-		if(array_key_exists('HTTPS', $_SERVER) && $_SERVER["HTTPS"]=='on') {
-			$url = "https://".$_SERVER['SERVER_NAME'].$target;
-		} else {
-			$url = "http://".@$_SERVER['SERVER_NAME'].$target;
-		}
+		// $installURL is blank so let's just give the target back
+		$url = $target;
 	}
 	return $url;
 }


### PR DESCRIPTION
If you install the server behind a proxy, you have to use
X_FORWARDED_FOR values to detect the correct hostname.  The detection
also failed when the service was served on a different port than the
standard 443 or 80.
By removing the URL of the server you can prevent this problems.
According to the mozilla documention [1], using the relative URL is
perfectly correct.

[1] https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Location