### PR TITLE
Saml updates

### DIFF
--- a/api/v1/index.php
+++ b/api/v1/index.php
@@ -5,7 +5,7 @@
 	// Not really a loginPage, but this variable will keep us from getting redirected when
 	// using LDAP auth and there's no session (so true RESTful API capability)
 	//
-	if ( AUTHENTICATION == "LDAP" ) {
+	if ( AUTHENTICATION == "LDAP" || AUTHENTICATION == 'Saml' ) {
 		$loginPage = true;
 	}
 
@@ -132,7 +132,7 @@ $app->add(function($request, $response, $next) use($person) {
 
 //	Slim Framework 2 middleware
 $app->hook( 'slim.before.dispatch', function() use($person) {
-	if ( AUTHENTICATION == "LDAP" || AUTHENTICATION == "AD" ) {
+	if ( AUTHENTICATION == "LDAP" || AUTHENTICATION == "AD" || AUTHENTICATION == "Saml" ) {
 		// Getting request headers
 		$headers = apache_request_headers();
 		$response = array();

--- a/misc.inc.php
+++ b/misc.inc.php
@@ -870,7 +870,7 @@ if(!function_exists("updateNavTreeHTML")){
 if( AUTHENTICATION=="Saml" && !isset($_SESSION['userid']) && php_sapi_name()!="cli" ){
 	$savedurl = $_SERVER['SCRIPT_NAME'] . "?" . sanitize($_SERVER['QUERY_STRING']);
 	setcookie( 'targeturl', $savedurl, time()+60 );
-	header("Location: ".redirect('saml/login.php'));
+	header("Location: ".redirect($config->ParameterArray["InstallURL"].'/saml/login.php'));
 	exit;
 }
 

--- a/misc.inc.php
+++ b/misc.inc.php
@@ -867,7 +867,8 @@ if(!function_exists("updateNavTreeHTML")){
 	we are.  It may be needed for the installation.
 */
 
-if( AUTHENTICATION=="Saml" && !isset($_SESSION['userid']) && php_sapi_name()!="cli" ){
+if( AUTHENTICATION=="Saml" && !isset($_SESSION['userid']) && php_sapi_name()!="cli" && !isset($loginPage))
+{
 	$savedurl = $_SERVER['SCRIPT_NAME'] . "?" . sanitize($_SERVER['QUERY_STRING']);
 	setcookie( 'targeturl', $savedurl, time()+60 );
 	header("Location: ".redirect('saml/login.php'));
@@ -916,7 +917,7 @@ if(!People::Current()){
 	if(AUTHENTICATION=="Oauth"){
 		header("Location: ".redirect('oauth/login.php'));
 		exit;
-	} elseif ( AUTHENTICATION=="Saml"){
+	} elseif ( AUTHENTICATION=="Saml" && !isset($loginPage) ){
 		header("Location: ".redirect('saml/login.php'));
 		exit;
 	} elseif ( AUTHENTICATION=="LDAP" && !isset($loginPage) ) {
@@ -1011,6 +1012,14 @@ if( AUTHENTICATION == "LDAP" ) {
 	}
 	$lmenu[]='<a href="login_ldap.php?logout"><span>'.__("Logout").'</span></a>';
 }
+# Can really think that this is necessary - here for completemess
+#if( AUTHENTICATION == "Saml" ) {
+#	// Clear out the Reports menu button and create the Login menu button when not logged in
+#	if ( isset($loginPage) ) {
+#		$rmenu = array();
+#	}
+#	$lmenu[]='<a href="saml/logout.php"><span>'.__("Logout").'</span></a>';
+#}
 
 function download_file($archivo, $downloadfilename = null) {
 	if (file_exists($archivo)) {

--- a/misc.inc.php
+++ b/misc.inc.php
@@ -868,6 +868,8 @@ if(!function_exists("updateNavTreeHTML")){
 */
 
 if( AUTHENTICATION=="Saml" && !isset($_SESSION['userid']) && php_sapi_name()!="cli" ){
+	$savedurl = $_SERVER['SCRIPT_NAME'] . "?" . sanitize($_SERVER['QUERY_STRING']);
+	setcookie( 'targeturl', $savedurl, time()+60 );
 	header("Location: ".redirect('saml/login.php'));
 	exit;
 }

--- a/misc.inc.php
+++ b/misc.inc.php
@@ -98,7 +98,7 @@ Example usage:
 	exit;
 */
 function path(){
-	$path=explode("/",$_SERVER['REQUEST_URI']);
+	$path=explode("/",sanitize($_SERVER['REQUEST_URI']));
 	unset($path[(count($path)-1)]);
 	$path=implode("/",$path);
 	return $path;
@@ -870,7 +870,7 @@ if(!function_exists("updateNavTreeHTML")){
 if( AUTHENTICATION=="Saml" && !isset($_SESSION['userid']) && php_sapi_name()!="cli" ){
 	$savedurl = $_SERVER['SCRIPT_NAME'] . "?" . sanitize($_SERVER['QUERY_STRING']);
 	setcookie( 'targeturl', $savedurl, time()+60 );
-	header("Location: ".redirect($config->ParameterArray["InstallURL"].'/saml/login.php'));
+	header("Location: ".redirect('saml/login.php'));
 	exit;
 }
 

--- a/saml/acs.php
+++ b/saml/acs.php
@@ -56,7 +56,7 @@ if ($samlResponse->isValid($saml_reqID)) {
 	$userid = $check_username;
 
         if ($config->ParameterArray["SAMLShowSuccessPage"] == 'disabled') {
-		header('Location: ..');
+		header('Location: ' .$_POST['RelayState']);
 	}
 	$success = true;
 } else {
@@ -68,7 +68,7 @@ if ($samlResponse->isValid($saml_reqID)) {
 ?>
 <!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN">
 <html>
-<?php echo ($config->ParameterArray["SAMLShowSuccessPage"]=='enabled' ? '<meta http-equiv="refresh" content="2;url=..">' : '') 
+<?php echo ($config->ParameterArray["SAMLShowSuccessPage"]=='enabled' ? '<meta http-equiv="refresh" content="2;url='.$_POST['RelayState'].'">' : '') 
 ?>
 <head>
 <title>SAML client results</title>

--- a/saml/login.php
+++ b/saml/login.php
@@ -23,7 +23,11 @@ if (!isset($_SESSION['samlUserdata'])) {
 	$_SESSION['saml_req_id'] = $authRequest->getID();
 	
 	$parameters = array('SAMLRequest' => $samlRequest);
-	$parameters['RelayState'] = OneLogin_Saml2_Utils::getSelfURLNoQuery();
+
+	if(isset($_COOKIE['targeturl'])){
+		$relayto = html_entity_decode($_COOKIE['targeturl']);
+	}
+	$parameters['RelayState'] = (isset($relayto)?OneLogin_Saml2_Utils::getSelfURLhost().$relayto:OneLogin_Saml2_Utils::getSelfURLhost());
 
     	$idpData = $settings->getIdPData();
 	$ssoUrl = $idpData['singleSignOnService']['url'];

--- a/vendor/onelogin/php-saml/CHANGELOG
+++ b/vendor/onelogin/php-saml/CHANGELOG
@@ -1,5 +1,11 @@
 CHANGELOG
 =========
+v.2.16.0
+* Support SLO ResponseLocation
+* [#344](https://github.com/onelogin/php-saml/issues/344) Raise errors on IdPMetadataParser::parseRemoteXML and IdPMetadataParser::parseFileXML
+* Adjusted acs endpoint to extract NameQualifier and SPNameQualifier from SAMLResponse. Adjusted single logout service to provide NameQualifier and SPNameQualifier to logout method. Add getNameIdNameQualifier to Auth and SamlResponse. Extend logout method from Auth and LogoutRequest constructor to support SPNameQualifier parameter. Align LogoutRequest constructor with SAML specs
+* Add support for Subjects on AuthNRequests by the new parameter
+* Set strict=true on config examples
 
 v.2.15.0
 * Security improvement suggested by Nils Engelbertz to prevent DDOS by expansion of internally defined entities (XEE)

--- a/vendor/onelogin/php-saml/README.md
+++ b/vendor/onelogin/php-saml/README.md
@@ -7,6 +7,8 @@ Forget those complicated libraries and use this open source library provided
 and supported by OneLogin Inc.
 
 
+**The 3.X branch is compatible with PHP > 7.1, so if you are using that PHP version, use it and not the 2.X or the master branch**
+
 Warning
 -------
 
@@ -287,7 +289,7 @@ $settings = array (
     // or unencrypted messages if it expects them to be signed or encrypted.
     // Also it will reject the messages if the SAML standard is not strictly
     // followed: Destination, NameId, Conditions ... are validated too.
-    'strict' => false,
+    'strict' => true,
 
     // Enable debug mode (to print errors).
     'debug' => false,
@@ -647,13 +649,14 @@ $auth = new OneLogin_Saml2_Auth();
 $auth->login($newTargetUrl);
 ```
 
-The login method can receive other five optional parameters:
+The login method can receive other six optional parameters:
 
 * `$parameters` - An array of parameters that will be added to the `GET` in the HTTP-Redirect.
 * `$forceAuthn` - When true the `AuthNRequest` will set the `ForceAuthn='true'`
 * `$isPassive` - When true the `AuthNRequest` will set the `Ispassive='true'`
 * `$strict` - True if we want to stay (returns the url string) False to redirect
 * `$setNameIdPolicy` - When true the AuthNRequest will set a nameIdPolicy element.
+* `$nameIdValueReq` - Indicates to the IdP the subject that should be authenticated.
 
 If a match on the future SAMLResponse ID and the AuthNRequest ID to be sent is required, that AuthNRequest ID must to be extracted and saved.
 
@@ -752,6 +755,8 @@ if (!$auth->isAuthenticated()) {
 $_SESSION['samlUserdata'] = $auth->getAttributes();
 $_SESSION['samlNameId'] = $auth->getNameId();
 $_SESSION['samlNameIdFormat'] = $auth->getNameIdFormat();
+$_SESSION['samlNameidNameQualifier' = $auth->getNameIdNameQualifier();
+$_SESSION['samlNameidSPNameQualifier' = $auth->getNameIdSPNameQualifier();
 $_SESSION['samlSessionIndex'] = $auth->getSessionIndex();
 
 if (isset($_POST['RelayState']) && OneLogin_Saml2_Utils::getSelfURL() != $_POST['RelayState']) {
@@ -979,7 +984,7 @@ $auth = new OneLogin_Saml2_Auth();
 $auth->logout();   // Method that sent the Logout Request.
 ```
 
-Also there are six optional parameters that can be set:
+Also there are eight optional parameters that can be set:
 * `$returnTo` - The target URL the user should be returned to after logout.
 * `$parameters` - Extra parameters to be added to the GET.
 * `$name_id` - That will be used to build the LogoutRequest. If `name_id` parameter is not set and the auth object processed a
@@ -987,6 +992,8 @@ SAML Response with a `NameId`, then this `NameId` will be used.
 * `$session_index` - SessionIndex that identifies the session of the user.
 * `$stay` - True if we want to stay (returns the url string) False to redirect.
 * `$nameIdFormat` - The NameID Format will be set in the LogoutRequest.
+* `$nameIdNameQualifier` - The NameID NameQualifier will be set in the LogoutRequest.
+* `$nameIdSPNameQualifier` - The NameID SP NameQualifier will be set in the LogoutRequest.
 
 The Logout Request will be sent signed or unsigned based on the security
 info of the `advanced_settings.php` (`'logoutRequestSigned'`).
@@ -1013,6 +1020,9 @@ $paramters = array();
 $nameId = null;
 $sessionIndex = null;
 $nameIdFormat = null;
+$nameIdNameQualifier = null;
+$nameIdSPNameQualifier = null;
+
 if (isset($_SESSION['samlNameId'])) {
     $nameId = $_SESSION['samlNameId'];
 }
@@ -1022,7 +1032,13 @@ if (isset($_SESSION['samlSessionIndex'])) {
 if (isset($_SESSION['samlNameIdFormat'])) {
     $nameIdFormat = $_SESSION['samlNameIdFormat'];
 }
-$auth->logout($returnTo, $paramters, $nameId, $sessionIndex, false, $nameIdFormat);
+if (isset($_SESSION['samlNameIdNameQualifier'])) {
+    $nameIdNameQualifier = $_SESSION['samlNameIdNameQualifier'];
+}
+if (isset($_SESSION['samlNameIdSPNameQualifier'])) {
+    $nameIdSPNameQualifier = $_SESSION['samlNameIdSPNameQualifier'];
+}
+$auth->logout($returnTo, $paramters, $nameId, $sessionIndex, false, $nameIdFormat, $nameIdNameQualifier, $nameIdSPNameQualifier);
 ```
 
 If a match on the future LogoutResponse ID and the LogoutRequest ID to be sent is required, that LogoutRequest ID must to be extracted and stored.
@@ -1116,6 +1132,46 @@ if (isset($_SESSION['samlUserdata'])) {   // If there is user data we print it.
     echo '<p><a href="?sso" >Login</a></p>';
     echo '<p><a href="?sso2" >Login and access to attrs.php page</a></p>';
 }
+```
+
+#### Example (using Composer) that initiates the SSO request and handles the response (is the acs target) ####
+
+Install package via composer:
+```
+composer require onelogin/php-saml
+```
+
+Create an index.php:
+```php
+<?php
+require('vendor/autoload.php');
+
+session_start();
+$needsAuth = empty($_SESSION['samlUserdata']);
+
+if ($needsAuth) {
+    // put SAML settings into an array to avoid placing files in the
+    // composer vendor/ directories 
+    $samlsettings = array(/*...config goes here...*/);
+    
+    $auth = new \OneLogin\Saml2\Auth($samlsettings);
+
+    if (!empty($_REQUEST['SAMLResponse']) && !empty($_REQUEST['RelayState'])) {
+        $auth->processResponse(null);
+        $errors = $auth->getErrors();
+        if (empty($errors)) {
+            // user has authenticated successfully
+            $needsAuth = false;
+            $_SESSION['samlUserdata'] = $auth->getAttributes();
+        }
+    }
+
+    if ($needsAuth) {
+        $auth->login();
+    }
+}
+
+// rest of your app goes here
 ```
 
 #### URL-guessing methods ####
@@ -1241,6 +1297,9 @@ Main class of OneLogin PHP Toolkit
  * `getAttributes` - Returns the set of SAML attributes.
  * `getAttribute` - Returns the requested SAML attribute
  * `getNameId` - Returns the nameID
+ * `getNameIdFormat` - Gets the NameID Format provided by the SAML response from the IdP.
+ * `getNameIdNameQualifier` - Gets the NameID NameQualifier provided from the SAML Response String.
+ * `getNameIdNameSPQualifier` - Gets the NameID SP NameQualifier provided from the SAML Response String.
  * `getSessionIndex` - Gets the SessionIndex from the AuthnStatement.
  * `getErrors` - Returns if there were any error
  * `getSSOurl` - Gets the SSO url.
@@ -1277,6 +1336,8 @@ SAML 2 Authentication Response class
    IdP.
  * `getNameId` - Gets the NameID provided by the SAML response from the IdP.
  * `getNameIdFormat` - Gets the NameID Format provided by the SAML response from the IdP.
+ * `getNameIdNameQualifier` - Gets the NameID NameQualifier provided from the SAML Response String.
+ * `getNameIdNameSPQualifier` - Gets the NameID SP NameQualifier provided from the SAML Response String.
  * `getSessionNotOnOrAfter` - Gets the SessionNotOnOrAfter from the
    AuthnStatement
  * `getSessionIndex` - Gets the SessionIndex from the AuthnStatement.

--- a/vendor/onelogin/php-saml/demo1/index.php
+++ b/vendor/onelogin/php-saml/demo1/index.php
@@ -35,14 +35,20 @@ if (isset($_GET['sso'])) {
     if (isset($_SESSION['samlNameId'])) {
         $nameId = $_SESSION['samlNameId'];
     }
-    if (isset($_SESSION['samlSessionIndex'])) {
-        $sessionIndex = $_SESSION['samlSessionIndex'];
-    }
     if (isset($_SESSION['samlNameIdFormat'])) {
         $nameIdFormat = $_SESSION['samlNameIdFormat'];
     }
+    if (isset($_SESSION['samlNameIdNameQualifier'])) {
+        $nameIdNameQualifier = $_SESSION['samlNameIdNameQualifier'];
+    }
+    if (isset($_SESSION['samlNameIdSPNameQualifier'])) {
+        $nameIdSPNameQualifier = $_SESSION['samlNameIdSPNameQualifier'];
+    }
+    if (isset($_SESSION['samlSessionIndex'])) {
+        $sessionIndex = $_SESSION['samlSessionIndex'];
+    }
 
-    $auth->logout($returnTo, $parameters, $nameId, $sessionIndex, false, $nameIdFormat);
+    $auth->logout($returnTo, $parameters, $nameId, $sessionIndex, false, $nameIdFormat, $nameIdNameQualifier, $nameIdSPNameQualifier);
 
     # If LogoutRequest ID need to be saved in order to later validate it, do instead
     # $sloBuiltUrl = $auth->logout(null, $paramters, $nameId, $sessionIndex, true);
@@ -75,6 +81,8 @@ if (isset($_GET['sso'])) {
     $_SESSION['samlUserdata'] = $auth->getAttributes();
     $_SESSION['samlNameId'] = $auth->getNameId();
     $_SESSION['samlNameIdFormat'] = $auth->getNameIdFormat();
+    $_SESSION['samlNameIdNameQualifier'] = $auth->getNameIdNameQualifier();
+    $_SESSION['samlNameIdSPNameQualifier'] = $auth->getNameIdSPNameQualifier();
     $_SESSION['samlSessionIndex'] = $auth->getSessionIndex();
     unset($_SESSION['AuthNRequestID']);
     if (isset($_POST['RelayState']) && OneLogin_Saml2_Utils::getSelfURL() != $_POST['RelayState']) {

--- a/vendor/onelogin/php-saml/lib/Saml2/Auth.php
+++ b/vendor/onelogin/php-saml/lib/Saml2/Auth.php
@@ -50,6 +50,13 @@ class OneLogin_Saml2_Auth
     private $_nameidNameQualifier;
 
     /**
+     * NameID SP NameQualifier
+     *
+     * @var string
+     */
+    private $_nameidSPNameQualifier;
+
+    /**
      * If user is authenticated.
      *
      * @var bool
@@ -197,6 +204,7 @@ class OneLogin_Saml2_Auth
                 $this->_nameid = $response->getNameId();
                 $this->_nameidFormat = $response->getNameIdFormat();
                 $this->_nameidNameQualifier = $response->getNameIdNameQualifier();
+                $this->_nameidSPNameQualifier = $response->getNameIdSPNameQualifier();
                 $this->_authenticated = true;
                 $this->_sessionIndex = $response->getSessionIndex();
                 $this->_sessionExpiration = $response->getSessionNotOnOrAfter();
@@ -381,6 +389,16 @@ class OneLogin_Saml2_Auth
     }
 
     /**
+     * Returns the nameID SP NameQualifier
+     *
+     * @return string  The nameID SP NameQualifier of the assertion
+     */
+    public function getNameIdSPNameQualifier()
+    {
+        return $this->_nameidSPNameQualifier;
+    }
+
+    /**
      * Returns the SessionIndex
      *
      * @return string|null  The SessionIndex of the assertion
@@ -465,16 +483,17 @@ class OneLogin_Saml2_Auth
      * @param bool $isPassive When true the AuthNRequest will set the Ispassive='true'
      * @param bool $stay True if we want to stay (returns the url string) False to redirect
      * @param bool $setNameIdPolicy When true the AuthNRueqest will set a nameIdPolicy element
+     * @param string $nameIdValueReq Indicates to the IdP the subject that should be authenticated
      *
      * @return string|null If $stay is True, it return a string with the SLO URL + LogoutRequest + parameters
      *
      * @throws OneLogin_Saml2_Error
      */
-    public function login($returnTo = null, $parameters = array(), $forceAuthn = false, $isPassive = false, $stay = false, $setNameIdPolicy = true)
+    public function login($returnTo = null, $parameters = array(), $forceAuthn = false, $isPassive = false, $stay = false, $setNameIdPolicy = true, $nameIdValueReq = null)
     {
         assert('is_array($parameters)');
 
-        $authnRequest = new OneLogin_Saml2_AuthnRequest($this->_settings, $forceAuthn, $isPassive, $setNameIdPolicy);
+        $authnRequest = new OneLogin_Saml2_AuthnRequest($this->_settings, $forceAuthn, $isPassive, $setNameIdPolicy, $nameIdValueReq);
 
         $this->_lastRequest = $authnRequest->getXML();
         $this->_lastRequestID = $authnRequest->getId();
@@ -512,7 +531,7 @@ class OneLogin_Saml2_Auth
      *
      * @throws OneLogin_Saml2_Error
      */
-    public function logout($returnTo = null, $parameters = array(), $nameId = null, $sessionIndex = null, $stay = false, $nameIdFormat = null, $nameIdNameQualifier = null)
+    public function logout($returnTo = null, $parameters = array(), $nameId = null, $sessionIndex = null, $stay = false, $nameIdFormat = null, $nameIdNameQualifier = null, $nameIdSPNameQualifier = null)
     {
         assert('is_array($parameters)');
 
@@ -531,7 +550,7 @@ class OneLogin_Saml2_Auth
             $nameIdFormat = $this->_nameidFormat;
         }
 
-        $logoutRequest = new OneLogin_Saml2_LogoutRequest($this->_settings, null, $nameId, $sessionIndex, $nameIdFormat, $nameIdNameQualifier);
+        $logoutRequest = new OneLogin_Saml2_LogoutRequest($this->_settings, null, $nameId, $sessionIndex, $nameIdFormat, $nameIdNameQualifier, $nameIdSPNameQualifier);
 
         $this->_lastRequest = $logoutRequest->getXML();
         $this->_lastRequestID = $logoutRequest->id;
@@ -649,7 +668,7 @@ class OneLogin_Saml2_Auth
      *
      * @throws OneLogin_Saml2_Error
      */
-    private function buildMessageSignature($samlMessage, $relayState, $signAlgorithm = XMLSecurityKey::RSA_SHA256, $type="SAMLRequest")
+    private function buildMessageSignature($samlMessage, $relayState, $signAlgorithm = XMLSecurityKey::RSA_SHA256, $type = "SAMLRequest")
     {
         $key = $this->_settings->getSPkey();
         if (empty($key)) {

--- a/vendor/onelogin/php-saml/lib/Saml2/IdPMetadataParser.php
+++ b/vendor/onelogin/php-saml/lib/Saml2/IdPMetadataParser.php
@@ -40,6 +40,7 @@ class OneLogin_Saml2_IdPMetadataParser
                 throw new Exception(curl_error($ch), curl_errno($ch));
             }
         } catch (Exception $e) {
+            throw new Exception('Error on parseRemoteXML. '.$e->getMessage());
         }
         return $metadataInfo;
     }
@@ -68,6 +69,7 @@ class OneLogin_Saml2_IdPMetadataParser
                 $metadataInfo = self::parseXML($data, $entityId, $desiredNameIdFormat, $desiredSSOBinding, $desiredSLOBinding);
             }
         } catch (Exception $e) {
+            throw new Exception('Error on parseFileXML. '.$e->getMessage());
         }
         return $metadataInfo;
     }

--- a/vendor/onelogin/php-saml/lib/Saml2/LogoutRequest.php
+++ b/vendor/onelogin/php-saml/lib/Saml2/LogoutRequest.php
@@ -39,10 +39,11 @@ class OneLogin_Saml2_LogoutRequest
      * @param string|null $sessionIndex The SessionIndex (taken from the SAML Response in the SSO process).
      * @param string|null $nameIdFormat The NameID Format will be set in the LogoutRequest.
      * @param string|null $nameIdNameQualifier The NameID NameQualifier will be set in the LogoutRequest.
+     * @param string|null             $nameIdSPNameQualifier The NameID SP NameQualifier will be set in the LogoutRequest.
      *
      * @throws OneLogin_Saml2_Error
      */
-    public function __construct(OneLogin_Saml2_Settings $settings, $request = null, $nameId = null, $sessionIndex = null, $nameIdFormat = null, $nameIdNameQualifier = null)
+    public function __construct(OneLogin_Saml2_Settings $settings, $request = null, $nameId = null, $sessionIndex = null, $nameIdFormat = null, $nameIdNameQualifier = null, $nameIdSPNameQualifier = null)
     {
         $this->_settings = $settings;
 
@@ -59,7 +60,6 @@ class OneLogin_Saml2_LogoutRequest
             $id = OneLogin_Saml2_Utils::generateUniqueID();
             $this->id = $id;
 
-            $nameIdValue = OneLogin_Saml2_Utils::generateUniqueID();
             $issueInstant = OneLogin_Saml2_Utils::parseTime2SAML(time());
 
             $cert = null;
@@ -78,16 +78,26 @@ class OneLogin_Saml2_LogoutRequest
                   $spData['NameIDFormat'] != OneLogin_Saml2_Constants::NAMEID_UNSPECIFIED) {
                     $nameIdFormat = $spData['NameIDFormat'];
                 }
-                $spNameQualifier = null;
             } else {
                 $nameId = $idpData['entityId'];
                 $nameIdFormat = OneLogin_Saml2_Constants::NAMEID_ENTITY;
-                $spNameQualifier = $spData['entityId'];
+            }
+
+            /* From saml-core-2.0-os 8.3.6, when the entity Format is used:
+               "The NameQualifier, SPNameQualifier, and SPProvidedID attributes MUST be omitted.
+            */
+            if (!empty($nameIdFormat) && $nameIdFormat == OneLogin_Saml2_Constants::NAMEID_ENTITY) {
+                $nameIdNameQualifier = null;
+                $nameIdSPNameQualifier = null;
+            }
+             // NameID Format UNSPECIFIED omitted
+            if (!empty($nameIdFormat) && $nameIdFormat == OneLogin_Saml2_Constants::NAMEID_UNSPECIFIED) {
+                $nameIdFormat = null;
             }
 
             $nameIdObj = OneLogin_Saml2_Utils::generateNameId(
                 $nameId,
-                $spNameQualifier,
+                $nameIdSPNameQualifier,
                 $nameIdFormat,
                 $cert,
                 $nameIdNameQualifier

--- a/vendor/onelogin/php-saml/lib/Saml2/Response.php
+++ b/vendor/onelogin/php-saml/lib/Saml2/Response.php
@@ -672,6 +672,23 @@ class OneLogin_Saml2_Response
     }
 
     /**
+     * Gets the NameID SP NameQualifier provided by the SAML response from the IdP.
+     *
+     * @return string|null NameID SP NameQualifier
+     *
+     * @throws ValidationError
+     */
+    public function getNameIdSPNameQualifier()
+    {
+        $nameIdSPNameQualifier = null;
+        $nameIdData = $this->getNameIdData();
+        if (!empty($nameIdData) && isset($nameIdData['SPNameQualifier'])) {
+            $nameIdSPNameQualifier = $nameIdData['SPNameQualifier'];
+        }
+        return $nameIdSPNameQualifier;
+    }
+
+    /**
      * Gets the SessionNotOnOrAfter from the AuthnStatement.
      * Could be used to set the local session expiration
      *

--- a/vendor/onelogin/php-saml/lib/Saml2/version.json
+++ b/vendor/onelogin/php-saml/lib/Saml2/version.json
@@ -1,6 +1,6 @@
 {
     "php-saml": {
-        "version": "2.15.0",
-        "released": "28/01/2019"
+        "version": "2.16.0",
+        "released": "24/06/2019"
     }
 }

--- a/vendor/onelogin/php-saml/phpunit.xml
+++ b/vendor/onelogin/php-saml/phpunit.xml
@@ -1,0 +1,18 @@
+<phpunit bootstrap="./tests/bootstrap.php" colors="true">
+    <testsuites>
+        <testsuite name="OneLogin PHP-SAML Test Suite">
+            <directory>./tests/src</directory>
+        </testsuite>
+    </testsuites>
+    <filter>
+        <whitelist processUncoveredFilesFromWhitelist="true">
+            <directory>./lib</directory>
+        </whitelist>
+    </filter>
+   <logging>
+        <log type="coverage-html" target="./tests/build/coverage" charset="UTF-8" yui="true" highlight="false" lowUpperBound="35" highLowerBound="70"/>
+        <log type="test-xml" target="./tests/build/logfile.xml" logIncompleteSkipped="false"/>
+        <log type="coverage-clover" target="./tests/build/logs/clover.xml"/>
+        <log type="coverage-php" target="./tests/build/logs/coverage.cov"/>
+    </logging>
+</phpunit>

--- a/vendor/onelogin/php-saml/settings_example.php
+++ b/vendor/onelogin/php-saml/settings_example.php
@@ -5,7 +5,7 @@ $settings = array (
     // or unencrypted messages if it expects them signed or encrypted
     // Also will reject the messages if not strictly follow the SAML
     // standard: Destination, NameId, Conditions ... are validated too.
-    'strict' => false,
+    'strict' => true,
 
     // Enable debug mode (to print errors)
     'debug' => false,
@@ -27,7 +27,7 @@ $settings = array (
             'url' => '',
             // SAML protocol binding to be used when returning the <Response>
             // message.  Onelogin Toolkit supports for this endpoint the
-            // HTTP-Redirect binding only
+            // HTTP-POST binding only
             'binding' => 'urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST',
         ),
         // If you need to specify requested attributes, set a
@@ -86,7 +86,7 @@ $settings = array (
             'url' => '',
             // SAML protocol binding to be used when returning the <Response>
             // message.  Onelogin Toolkit supports for this endpoint the
-            // HTTP-POST binding only
+            // HTTP-Redirect binding only
             'binding' => 'urn:oasis:names:tc:SAML:2.0:bindings:HTTP-Redirect',
         ),
         // SLO endpoint info of the IdP.


### PR DESCRIPTION
This includes the following:
1. SAML: Go to the originally requested page after authentication 

originally went to default page

2. SAML: Use Absolute URL to do the redirect to the SAML login page

There appeared to be an issue if something unexpected was added to the URI when using the relative link.  This sorts that out but does require the OpenDCIM base URL to be correctly set.

3. onelogin/php-saml: Upgrade version to 2.16.0
A number of changes from the upstream project nothing major or security related



