### PR TITLE
Remotes/origin/1133 stop requiring logo.png to be in /images

### DIFF
--- a/cabaudit.php
+++ b/cabaudit.php
@@ -43,7 +43,7 @@ class PDF extends FPDF {
   
 	function Header() {
 		$this->pdfconfig = new Config();
-    	$this->Image( 'images/' . $this->pdfconfig->ParameterArray['PDFLogoFile'],10,8,100);
+    	$this->Image(  $this->pdfconfig->ParameterArray['PDFLogoFile'],10,8,100);
     	$this->SetFont($this->pdfconfig->ParameterArray['PDFfont'],'B',12);
     	$this->Cell(120);
     	$this->Cell(40,20,__("Information Technology Services"),0,0,'C');

--- a/classes/Device.class.php
+++ b/classes/Device.class.php
@@ -2457,7 +2457,7 @@ class Device {
 				$error.=__("Facility Manager email address").": <span class=\"errmsg\">".$e->getMessage()."</span><br>\n";
 			}
 
-			$logofile=getcwd().'/images/'.$config->ParameterArray["PDFLogoFile"];
+			$logofile=getcwd().'/'.$config->ParameterArray["PDFLogoFile"];
 			$logo=$message->embed(Swift_Image::fromPath($logofile)->setFilename($logofile));
 				
 			$style = "

--- a/classes/PowerDistribution.class.php
+++ b/classes/PowerDistribution.class.php
@@ -515,7 +515,7 @@ class PowerDistribution {
 				$error.=__("Facility Manager email address").": <span class=\"errmsg\">".$e->getMessage()."</span><br>\n";
 			}
 
-			$logofile=getcwd().'/images/'.$config->ParameterArray["PDFLogoFile"];
+			$logofile=getcwd().'/'.$config->ParameterArray["PDFLogoFile"];
 			$logo=$message->embed(Swift_Image::fromPath($logofile)->setFilename($logofile));
 				
 			$style = "

--- a/create.sql
+++ b/create.sql
@@ -812,7 +812,7 @@ INSERT INTO fac_Config VALUES
 	('annualCostPerUYear','200','Dollars','float','200'),
 	('Locale','en_US.utf8','TextLocale','string','en_US.utf8'),
 	('timezone', 'America/Chicago', 'string', 'string', 'America/Chicago'),
-	('PDFLogoFile','logo.png','Filename','string','logo.png'),
+	('PDFLogoFile','images/logo.png','Filename','string','images/logo.png'),
 	('PDFfont','Arial','Font','string','Arial'),
 	('SMTPServer','smtp.your.domain','Server','string','smtp.your.domain'),
 	('SMTPPort','25','Port','int','25'),

--- a/css/inventory.php
+++ b/css/inventory.php
@@ -93,7 +93,7 @@ textarea {white-space: pre;word-wrap: break-word;}
 /*  Header/logo */
 #header{
 	padding:5px 0;
-	background:<?php echo $config->ParameterArray['HeaderColor']; ?> url(../images/<?php echo $config->ParameterArray['PDFLogoFile']; ?>) no-repeat left center;
+	background:<?php echo $config->ParameterArray['HeaderColor']; ?> url(../<?php echo $config->ParameterArray['PDFLogoFile']; ?>) no-repeat left center;
 	height:66px;
 	position: relative;
 }

--- a/rackrequest.php
+++ b/rackrequest.php
@@ -72,7 +72,7 @@
 			$error.=__("Data center team address").": <span class=\"errmsg\">".$e->getMessage()."</span><br>\n";
 		}
 
-		$logo='images/'.$config->ParameterArray["PDFLogoFile"];
+		$logo=$config->ParameterArray["PDFLogoFile"];
 		$logo=$message->embed(Swift_Image::fromPath($logo)->setFilename('logo.png'));
 
 		$htmlMessage='<!doctype html><html><head><meta http-equiv="Content-Type" content="text/html; charset=UTF-8"><title>ITS Data Center Inventory</title></head><body><div id="header" style="padding: 5px 0;background: '.$config->ParameterArray["HeaderColor"].';"><center><img src="'.$logo.'"></center></div><div class="page"><p><h3>'.__("ITS Facilities Rack Request").'</h3>'."\n";

--- a/report-Excel_Template.php
+++ b/report-Excel_Template.php
@@ -29,7 +29,7 @@
     $objDrawing->setWorksheet($sheet);
     $objDrawing->setName("Logo");
     $objDrawing->setDescription("Logo");
-    $apath = __DIR__ . DIRECTORY_SEPARATOR . 'images' . DIRECTORY_SEPARATOR;
+    $apath = __DIR__ . DIRECTORY_SEPARATOR ;
     $objDrawing->setPath($apath . $config->ParameterArray['PDFLogoFile']);
     $objDrawing->setCoordinates('A1');
     $objDrawing->setOffsetX(5);

--- a/report-asset_aging.php
+++ b/report-asset_aging.php
@@ -35,7 +35,7 @@
     $objDrawing->setWorksheet($sheet);
     $objDrawing->setName("Logo");
     $objDrawing->setDescription("Logo");
-    $apath = __DIR__ . DIRECTORY_SEPARATOR . 'images' . DIRECTORY_SEPARATOR;
+    $apath = __DIR__ . DIRECTORY_SEPARATOR ;
     $objDrawing->setPath($apath . $config->ParameterArray['PDFLogoFile']);
     $objDrawing->setCoordinates('A1');
     $objDrawing->setOffsetX(5);

--- a/report-em_disabled_snmp.php
+++ b/report-em_disabled_snmp.php
@@ -33,7 +33,7 @@
 		$error.=__("Facility Manager email address").": <span class=\"errmsg\">".$e->getMessage()."</span><br>\n";
 	}
 
-	$logo=getcwd().'/images/'.$config->ParameterArray["PDFLogoFile"];
+	$logo=getcwd().'/'.$config->ParameterArray["PDFLogoFile"];
 	$logo=$message->embed(Swift_Image::fromPath($logo)->setFilename('logo.png'));
 
 	$htmlMessage = sprintf( "<!doctype html><html><head><meta http-equiv=\"Content-Type\" content=\"text/html; charset=UTF-8\"><title>ITS Data Center Inventory</title></head><body><div id=\"header\" style=\"padding: 5px 0;background: %s;\"><center><img src=\"%s\"></center></div><div class=\"page\"><p>\n", $config->ParameterArray["HeaderColor"], $logo );

--- a/report-em_new_installs.php
+++ b/report-em_new_installs.php
@@ -36,7 +36,7 @@
 		$error.=__("Facility Manager email address").": <span class=\"errmsg\">".$e->getMessage()."</span><br>\n";
 	}
 
-	$logo=getcwd().'/images/'.$config->ParameterArray["PDFLogoFile"];
+	$logo=getcwd().'/'.$config->ParameterArray["PDFLogoFile"];
 	$logo=$message->embed(Swift_Image::fromPath($logo)->setFilename('logo.png'));
 
 	$htmlMessage = sprintf( "<!doctype html><html><head><meta http-equiv=\"Content-Type\" content=\"text/html; charset=UTF-8\"><title>ITS Data Center Inventory</title></head><body><div id=\"header\" style=\"padding: 5px 0;background: %s;\"><center><img src=\"%s\"></center></div><div class=\"page\"><p><h3>Installations in the Past 7 Days</h3>\n", $config->ParameterArray["HeaderColor"], $logo );

--- a/report-em_reservations.php
+++ b/report-em_reservations.php
@@ -33,7 +33,7 @@
 		$error.=__("Facility Manager email address").": <span class=\"errmsg\">".$e->getMessage()."</span><br>\n";
 	}
 
-	$logo=getcwd().'/images/'.$config->ParameterArray["PDFLogoFile"];
+	$logo=getcwd().'/'.$config->ParameterArray["PDFLogoFile"];
 	$logo=$message->embed(Swift_Image::fromPath($logo)->setFilename('logo.png'));
 	
 	$style = "

--- a/report-em_switch_exceptions.php
+++ b/report-em_switch_exceptions.php
@@ -33,7 +33,7 @@
 		$error.=__("Facility Manager email address").": <span class=\"errmsg\">".$e->getMessage()."</span><br>\n";
 	}
 
-	$logo=getcwd().'/images/'.$config->ParameterArray["PDFLogoFile"];
+	$logo=getcwd().'/'.$config->ParameterArray["PDFLogoFile"];
 	$logo=$message->embed(Swift_Image::fromPath($logo)->setFilename('logo.png'));
 
 	$htmlMessage = sprintf( "<!doctype html><html><head><meta http-equiv=\"Content-Type\" content=\"text/html; charset=UTF-8\"><title>ITS Data Center Inventory</title></head><body><div id=\"header\" style=\"padding: 5px 0;background: %s;\"><center><img src=\"%s\"></center></div><div class=\"page\"><p>\n", $config->ParameterArray["HeaderColor"], $logo );

--- a/report_aging.php
+++ b/report_aging.php
@@ -83,8 +83,8 @@ class PDF extends FPDF
 
     function Header() {
         $this->pdfconfig = new Config();
-        if ( file_exists( 'images/' . $this->pdfconfig->ParameterArray['PDFLogoFile'] )) {
-            $this->Image( 'images/' . $this->pdfconfig->ParameterArray['PDFLogoFile'],10,8,100);
+        if ( file_exists(  $this->pdfconfig->ParameterArray['PDFLogoFile'] )) {
+            $this->Image(  $this->pdfconfig->ParameterArray['PDFLogoFile'],10,8,100);
         }
         $this->SetFont($this->pdfconfig->ParameterArray['PDFfont'], 'B', 12);
         $this->Cell(120);

--- a/report_asset.php
+++ b/report_asset.php
@@ -17,8 +17,8 @@ class PDF extends FPDF {
   
 	function Header() {
 		$this->pdfconfig = new Config();
-		if ( file_exists( 'images/' . $this->pdfconfig->ParameterArray['PDFLogoFile'] )) {
-	    	$this->Image( 'images/' . $this->pdfconfig->ParameterArray['PDFLogoFile'],10,8,100);
+		if ( file_exists(  $this->pdfconfig->ParameterArray['PDFLogoFile'] )) {
+	    	$this->Image(  $this->pdfconfig->ParameterArray['PDFLogoFile'],10,8,100);
 		}
     	$this->SetFont($this->pdfconfig->ParameterArray['PDFfont'],'B',12);
     	$this->Cell(120);

--- a/report_asset_Excel.php
+++ b/report_asset_Excel.php
@@ -1574,7 +1574,7 @@ function writeFrontPageContent($worksheet, $config, $DProps)
     $objDrawing->setWorksheet($worksheet);
     $objDrawing->setName($DProps['Front Page']['Logo Name']);
     $objDrawing->setDescription($DProps['Front Page']['Logo Description']);
-    $apath = __DIR__ . DIRECTORY_SEPARATOR . 'images' . DIRECTORY_SEPARATOR;
+    $apath = __DIR__ . DIRECTORY_SEPARATOR ;
     $objDrawing->setPath($apath . $config->ParameterArray['PDFLogoFile']);
     $objDrawing->setCoordinates('A1');
     $objDrawing->setOffsetX(5);

--- a/report_audit.php
+++ b/report_audit.php
@@ -36,8 +36,8 @@ class PDF extends FPDF {
 		
 		$this->pdfconfig = new Config();
 		$this->Link( 10, 8, 100, 20, 'https://' . $_SERVER['SERVER_NAME'] . $_SERVER['SCRIPT_NAME'] );
-		if ( file_exists( 'images/' . $this->pdfconfig->ParameterArray['PDFLogoFile'] )) {
-	    	$this->Image( 'images/' . $this->pdfconfig->ParameterArray['PDFLogoFile'],10,8,100);
+		if ( file_exists(  $this->pdfconfig->ParameterArray['PDFLogoFile'] )) {
+	    	$this->Image(  $this->pdfconfig->ParameterArray['PDFLogoFile'],10,8,100);
 		}
     	$this->SetFont($this->pdfconfig->ParameterArray['PDFfont'],'B',12);
     	$this->Cell(120);

--- a/report_audit_frequency.php
+++ b/report_audit_frequency.php
@@ -21,8 +21,8 @@ class PDF extends FPDF {
 	function Header() {
 		$this->pdfconfig = new Config();
 		$this->Link( 10, 8, 100, 20, 'https://' . $_SERVER['SERVER_NAME'] . $_SERVER['SCRIPT_NAME'] );
-		if ( file_exists( 'images/' . $this->pdfconfig->ParameterArray['PDFLogoFile'] )) {
-	    	$this->Image( 'images/' . $this->pdfconfig->ParameterArray['PDFLogoFile'],10,8,100);
+		if ( file_exists( $this->pdfconfig->ParameterArray['PDFLogoFile'] )) {
+	    	$this->Image(  $this->pdfconfig->ParameterArray['PDFLogoFile'],10,8,100);
 		}
     	$this->SetFont($this->pdfconfig->ParameterArray['PDFfont'],'B',12);
     	$this->Cell(120);

--- a/report_contact.php
+++ b/report_contact.php
@@ -29,8 +29,8 @@ class PDF extends FPDF {
 	
 	function Header() {
 		$this->pdfconfig = new Config();
-        if ( file_exists( 'images/' . $this->pdfconfig->ParameterArray['PDFLogoFile'] )) {
-            $this->Image( 'images/' . $this->pdfconfig->ParameterArray['PDFLogoFile'],10,8,100);
+        if ( file_exists(  $this->pdfconfig->ParameterArray['PDFLogoFile'] )) {
+            $this->Image(  $this->pdfconfig->ParameterArray['PDFLogoFile'],10,8,100);
         }
     	$this->SetFont($this->pdfconfig->ParameterArray['PDFfont'],'B',12);
     	$this->Cell(120);

--- a/report_cost.php
+++ b/report_cost.php
@@ -34,8 +34,8 @@ class PDF extends FPDF {
   
 	function Header() {
 		$this->pdfconfig = new Config();
-        if ( file_exists( 'images/' . $this->pdfconfig->ParameterArray['PDFLogoFile'] )) {
-            $this->Image( 'images/' . $this->pdfconfig->ParameterArray['PDFLogoFile'],10,8,100);
+        if ( file_exists(  $this->pdfconfig->ParameterArray['PDFLogoFile'] )) {
+            $this->Image(  $this->pdfconfig->ParameterArray['PDFLogoFile'],10,8,100);
         }
     	$this->SetFont($this->pdfconfig->ParameterArray["PDFfont"],'B',12);
     	$this->Cell(120);

--- a/report_department.php
+++ b/report_department.php
@@ -24,8 +24,8 @@ class PDF extends FPDF {
 	function Header() {
 		$this->pdfconfig = new Config();
 		$this->Link( 10, 8, 100, 20, 'https://' . $_SERVER['SERVER_NAME'] . $_SERVER['SCRIPT_NAME'] );
-        if ( file_exists( 'images/' . $this->pdfconfig->ParameterArray['PDFLogoFile'] )) {
-            $this->Image( 'images/' . $this->pdfconfig->ParameterArray['PDFLogoFile'],10,8,100);
+        if ( file_exists(  $this->pdfconfig->ParameterArray['PDFLogoFile'] )) {
+            $this->Image(  $this->pdfconfig->ParameterArray['PDFLogoFile'],10,8,100);
         }
     	$this->SetFont($this->pdfconfig->ParameterArray['PDFfont'],'B',12);
     	$this->Cell(120);

--- a/report_diverse_power_exceptions.php
+++ b/report_diverse_power_exceptions.php
@@ -23,8 +23,8 @@ class PDF extends FPDF {
   
 	function Header() {
 		$this->pdfconfig = new Config();
-    if ( file_exists( 'images/' . $this->pdfconfig->ParameterArray['PDFLogoFile'] )) {
-        $this->Image( 'images/' . $this->pdfconfig->ParameterArray['PDFLogoFile'],10,8,100);
+    if ( file_exists(  $this->pdfconfig->ParameterArray['PDFLogoFile'] )) {
+        $this->Image(  $this->pdfconfig->ParameterArray['PDFLogoFile'],10,8,100);
     }
   	$this->SetFont($this->pdfconfig->ParameterArray["PDFfont"],'B',12);
   	$this->Cell(120);

--- a/report_exception.php
+++ b/report_exception.php
@@ -28,8 +28,8 @@ class PDF extends FPDF {
   
 	function Header() {
 		$this->pdfconfig = new Config();
-		if ( file_exists( 'images/' . $this->pdfconfig->ParameterArray['PDFLogoFile'] )) {
-	    	$this->Image( 'images/' . $this->pdfconfig->ParameterArray['PDFLogoFile'],10,8,100);
+		if ( file_exists(  $this->pdfconfig->ParameterArray['PDFLogoFile'] )) {
+	    	$this->Image(  $this->pdfconfig->ParameterArray['PDFLogoFile'],10,8,100);
 		}
     	$this->SetFont($this->pdfconfig->ParameterArray['PDFfont'],'B',12);
     	$this->Cell(120);

--- a/report_power_distribution.php
+++ b/report_power_distribution.php
@@ -23,7 +23,7 @@ class PDF extends FPDF {
   
 	function Header() {
 		$this->pdfconfig = new Config();
-    	$logofile = 'images/' . $this->pdfconfig->ParameterArray['PDFLogoFile'];
+    	$logofile =  $this->pdfconfig->ParameterArray['PDFLogoFile'];
     	if ( file_exists( $logofile )) {
     		$this->Image( $logofile,10,8,100);
     	}

--- a/report_power_utilization.php
+++ b/report_power_utilization.php
@@ -23,8 +23,8 @@ class PDF extends FPDF {
   
 	function Header() {
 		$this->pdfconfig = new Config();
-    if ( file_exists( 'images/' . $this->pdfconfig->ParameterArray['PDFLogoFile'] )) {
-        $this->Image( 'images/' . $this->pdfconfig->ParameterArray['PDFLogoFile'],10,8,100);
+    if ( file_exists(  $this->pdfconfig->ParameterArray['PDFLogoFile'] )) {
+        $this->Image(  $this->pdfconfig->ParameterArray['PDFLogoFile'],10,8,100);
     }
   	$this->SetFont($this->pdfconfig->ParameterArray['PDFfont'],'B',12);
   	$this->Cell(120);

--- a/report_project_outage_simulator.php
+++ b/report_project_outage_simulator.php
@@ -607,7 +607,7 @@ if (!isset($_REQUEST['action'])){
 
 	$row++;
 	$activeSheet->setSelectedCell('K1');
-	$logo=getcwd().'/images/'.$config->ParameterArray["PDFLogoFile"];
+	$logo=getcwd().'/'.$config->ParameterArray["PDFLogoFile"];
 	$img = new PHPExcel_Worksheet_Drawing();
 	$img->setName($config->ParameterArray["PDFLogoFile"]);
 	$img->setPath($logo);

--- a/report_projects.php
+++ b/report_projects.php
@@ -63,7 +63,7 @@
         $objDrawing->setWorksheet($sheet);
         $objDrawing->setName("Logo");
         $objDrawing->setDescription("Logo");
-        $apath = __DIR__ . DIRECTORY_SEPARATOR . 'images' . DIRECTORY_SEPARATOR;
+        $apath = __DIR__ . DIRECTORY_SEPARATOR ;
         $objDrawing->setPath($apath . $config->ParameterArray['PDFLogoFile']);
         $objDrawing->setCoordinates('A1');
         $objDrawing->setOffsetX(5);

--- a/report_surplus.php
+++ b/report_surplus.php
@@ -65,7 +65,7 @@
 	    $objDrawing->setWorksheet($sheet);
 	    $objDrawing->setName("Logo");
 	    $objDrawing->setDescription("Logo");
-	    $apath = __DIR__ . DIRECTORY_SEPARATOR . 'images' . DIRECTORY_SEPARATOR;
+	    $apath = __DIR__ . DIRECTORY_SEPARATOR ;
 	    $objDrawing->setPath($apath . $config->ParameterArray['PDFLogoFile']);
 	    $objDrawing->setCoordinates('A1');
 	    $objDrawing->setOffsetX(5);

--- a/report_vendor_model.php
+++ b/report_vendor_model.php
@@ -115,7 +115,7 @@
         $objDrawing->setWorksheet($sheet);
         $objDrawing->setName("Logo");
         $objDrawing->setDescription("Logo");
-        $apath = __DIR__ . DIRECTORY_SEPARATOR . 'images' . DIRECTORY_SEPARATOR;
+        $apath = __DIR__ . DIRECTORY_SEPARATOR ;
         $objDrawing->setPath($apath . $config->ParameterArray['PDFLogoFile']);
         $objDrawing->setCoordinates('A1');
         $objDrawing->setOffsetX(5);

--- a/report_vm_by_department.php
+++ b/report_vm_by_department.php
@@ -29,8 +29,8 @@ class PDF extends FPDF {
   
 	function Header() {
 		$this->pdfconfig = new Config();
-		if ( file_exists( 'images/' . $this->pdfconfig->ParameterArray['PDFLogoFile'] )) {
-	    	$this->Image( 'images/' . $this->pdfconfig->ParameterArray['PDFLogoFile'],10,8,100);
+		if ( file_exists(  $this->pdfconfig->ParameterArray['PDFLogoFile'] )) {
+	    	$this->Image(  $this->pdfconfig->ParameterArray['PDFLogoFile'],10,8,100);
 		}
 
     	$this->SetFont($this->pdfconfig->ParameterArray['PDFfont'],'B',12);

--- a/report_warranty.php
+++ b/report_warranty.php
@@ -98,8 +98,8 @@ class PDF extends FPDF
 
     function Header() {
         $this->pdfconfig = new Config();
-        if ( file_exists( 'images/' . $this->pdfconfig->ParameterArray['PDFLogoFile'] )) {
-            $this->Image( 'images/' . $this->pdfconfig->ParameterArray['PDFLogoFile'],10,8,100);
+        if ( file_exists(  $this->pdfconfig->ParameterArray['PDFLogoFile'] )) {
+            $this->Image(  $this->pdfconfig->ParameterArray['PDFLogoFile'],10,8,100);
         }
         $this->SetFont($this->pdfconfig->ParameterArray['PDFfont'], 'B', 12);
         $this->Cell(120);

--- a/template_mpdf_reports.inc.php
+++ b/template_mpdf_reports.inc.php
@@ -74,7 +74,7 @@ EOT;
 <table width="100%"><tr>
 EOT;
 
-    $html .= '<td width="50%"><img src="images/'.$config->ParameterArray['PDFLogoFile'].'">';
+    $html .= '<td width="50%"><img src="'.$config->ParameterArray['PDFLogoFile'].'">';
     $html .= '<td width="50%" style="text-align: right;"><h4>'.$header.'<br>';
     $html .= __("Date").': '.strftime("%x").'</h4></td>';
 

--- a/vmnamecheck.php
+++ b/vmnamecheck.php
@@ -46,7 +46,7 @@
 		$error.=__("Data center team address").": <span class=\"errmsg\">".$e->getMessage()."</span><br>\n";
 	}
 
-	$logo=getcwd().'/images/'.$config->ParameterArray["PDFLogoFile"];
+	$logo=getcwd().'/'.$config->ParameterArray["PDFLogoFile"];
 	$logo=$message->embed(Swift_Image::fromPath($logo)->setFilename('logo.png'));
 	
 	$style = "

--- a/workorder.php
+++ b/workorder.php
@@ -72,7 +72,7 @@
 			$error.=__("Facility Manager email address").": <span class=\"errmsg\">".$e->getMessage()."</span><br>\n";
 		}
 
-		$logo=getcwd().'/images/'.$config->ParameterArray["PDFLogoFile"];
+		$logo=getcwd().'/'.$config->ParameterArray["PDFLogoFile"];
 		$logo=$message->embed(Swift_Image::fromPath($logo)->setFilename('logo.png'));
 
 		$htmlMessage = sprintf( "<!doctype html><html><head><meta http-equiv=\"Content-Type\" content=\"text/html; charset=UTF-8\"><title>Device Port Connections</title></head><body><div id=\"header\" style=\"padding: 5px 0;background: %s;\"><center><img src=\"%s\"></center></div><div class=\"page\">\n", $config->ParameterArray["HeaderColor"], $logo );


### PR DESCRIPTION
Hey,

here is a Patch for the Issue https://github.com/samilliken/openDCIM/issues/1133 the logo can now be in any directory above the webroot of the server