### PR TITLE
Fixes all tree expansion when viewing empty tree item

### DIFF
--- a/container_stats.php
+++ b/container_stats.php
@@ -137,6 +137,11 @@ echo '<div class="main">
 				},500);
 			}else{
 				var firstcabinet=$('#c<?php echo $c->ContainerID;?> > ul > li:first-child').attr('id');
+				// If we have no children,
+				if (typeof firstcabinet == 'undefined') {
+					// use the 1st-born child of our parent: may, or may not, be us
+					firstcabinet=$('#c<?php echo $c->ContainerID;?> ').attr('id');
+				}
 				expandToItem('datacenters',firstcabinet);
 			}
 		}

--- a/dc_stats.php
+++ b/dc_stats.php
@@ -369,6 +369,11 @@ echo '
 				},500);
 			}else{
 				var firstcabinet=$('#dc<?php echo $dc->DataCenterID;?> > ul > li:first-child').attr('id');
+				// If we have no children,
+				if (typeof firstcabinet == 'undefined') {
+					// use the 1st-born child of our parent: may, or may not, be us
+					firstcabinet=$('#dc<?php echo $dc->DataCenterID;?> ').attr('id');
+				}
 				expandToItem('datacenters',firstcabinet);
 			}
 		}

--- a/mapmaker.php
+++ b/mapmaker.php
@@ -256,6 +256,11 @@
 				},500);
 			}else{
 				var firstcabinet=$('#dc<?php echo $dc->DataCenterID;?> > ul > li:first-child').attr('id');
+				// If we have no children,
+				if (typeof firstcabinet == 'undefined') {
+					// use the 1st-born child of our parent: may, or may not, be us
+					firstcabinet=$('#dc<?php echo $dc->DataCenterID;?> ').attr('id');
+				}
 				expandToItem('datacenters',firstcabinet);
 			}
 		}

--- a/zone_stats.php
+++ b/zone_stats.php
@@ -341,6 +341,11 @@ echo '
 				},500);
 			}else{
 				var firstcabinet=$('#dc<?php echo $dc->DataCenterID;?> > ul > li:first-child').attr('id');
+				// If we have no children,
+				if (typeof firstcabinet == 'undefined') {
+					// use the 1st-born child of our parent: may, or may not, be us
+					firstcabinet=$('#dc<?php echo $dc->DataCenterID;?> ').attr('id');
+				}
 				expandToItem('datacenters',firstcabinet);
 			}
 		}


### PR DESCRIPTION
    As detailed on the mailing list, if we create an empty item,
     say a container, zone or data centre, so that we may attach
     an image to it, selecting the item so as to show the image
     causes the whole tree to be expanded and displayed.

    This occurs when the item that gets supplied, so as to define
     the level of the tree to be expanded is 'undefined'.

    This patch catches the 'undefined' and sets, as the level of
     the tree to be expanded, the first child at the level of the
     'undefined' item, which may or may not be that item.