### PR TITLE
Return Unauthorized if APIKey and UserID do not match

### DIFF
--- a/api/v1/index.php
+++ b/api/v1/index.php
@@ -161,6 +161,9 @@ $app->hook( 'slim.before.dispatch', function() use($person) {
 			$response['error'] = true;
 			$response['message'] = _("Access Denied");
 			$response['errorcode'] = 401;
+			echoResponse($response );
+			$app->stop();
+
 		}
 	}
 


### PR DESCRIPTION
This seems to have been broken around the time the move to Slim3 was reverted.  Was in 4.3.1

https://github.com/samilliken/openDCIM/blob/f00569c3329eaa30d4ddab1f4f46f7828c909834/api/v1/index.php#L152