### PR TITLE
display user login in the list

### DIFF
--- a/usermgr.php
+++ b/usermgr.php
@@ -233,7 +233,7 @@ echo '<div class="main">
 
 	foreach($userList as $userRow){
 		if($userRights->PersonID == $userRow->PersonID){$selected='selected';}else{$selected="";}
-		print "<option value=$userRow->PersonID $selected>" . $userRow->LastName . ", " . $userRow->FirstName. "</option>\n";
+		print "<option value=$userRow->PersonID $selected>" . $userRow->LastName . ", " . $userRow->FirstName . " (" . $userRow->UserID . ")" . "</option>\n";
 	}
 
 echo '	</select>&nbsp;&nbsp;<span title="',__("This user is the primary contact for this many devices"),'" id="PrimaryContact"></span></div>


### PR DESCRIPTION
Just a minor thing - but when users are created using Apache authentication these end up with both firstname and lastname undefined - only loginid is: as a result while editing user rights the list is composed of "," elements only ... which makes it little bit hard to use ... This PR proposes to add user login to the list.