### PR TITLE
avoid GetParentDevices time-expensive call

### DIFF
--- a/classes/Device.class.php
+++ b/classes/Device.class.php
@@ -1124,10 +1124,14 @@ class Device {
 		return $descList;
 	}
 	
-	function GetParentDevices(){
+	function GetParentDevices( $parDev = null ) {
 		global $dbh;
 		
-		$sql="SELECT * FROM fac_Device WHERE ChassisSlots>0 OR RearChassisSlots>0 ORDER BY Label ASC;";
+		if ( $parDev != null ) {
+			$sql="SELECT * FROM fac_Device WHERE DeviceID=". $parDev. ";";
+		} else {
+	  		$sql="SELECT * FROM fac_Device WHERE ChassisSlots>0 OR RearChassisSlots>0 ORDER BY Label ASC;";
+		}
 
 		$parentList=array();
 		foreach($dbh->query($sql) as $row){

--- a/classes/Device.class.php
+++ b/classes/Device.class.php
@@ -164,7 +164,7 @@ class Device {
 		$this->Notes=stripslashes($this->Notes);
 	}
 
-	static function RowToObject($dbRow,$filterrights=true,$extendmodel=true){
+	static function RowToObject($dbRow,$filterrights=true,$extendmodel=true,$customvalues=true){
 		/*
 		 * Generic function that will take any row returned from the fac_Devices
 		 * table and convert it to an object for use in array or other
@@ -219,7 +219,10 @@ class Device {
 		$dev->BackSide=$dbRow["BackSide"];
 		$dev->AuditStamp=$dbRow["AuditStamp"];
 		$dev->Weight=$dbRow["Weight"];
-		$dev->GetCustomValues();
+
+		if($customvalues){
+			$dev->GetCustomValues();
+		}
 		
 		$dev->MakeDisplay();
 
@@ -720,6 +723,14 @@ class Device {
 		// CLI call
 		if( php_sapi_name() != "cli" && $tmpDev->Rights!='Write'){return false;}
 	
+		// Check the user's permissions to attach to ParentDevice
+		if($this->ParentDevice){
+                        $parent=new Device();
+                        $parent->DeviceID=$this->ParentDevice;
+                        $parent->GetDevice();
+			if($parent->Rights!='Write'){return false;}
+                }
+		
 		$this->MakeSafe();	
 
 		if($tmpDev->Cabinet!=$this->Cabinet){
@@ -1124,21 +1135,18 @@ class Device {
 		return $descList;
 	}
 	
-	function GetParentDevices( $parDev = null ) {
+	function GetParentDevices($fullinfo=true) {
 		global $dbh;
 		
-		if ( $parDev != null ) {
-			$sql="SELECT * FROM fac_Device WHERE DeviceID=". $parDev. ";";
-		} else {
-	  		$sql="SELECT * FROM fac_Device WHERE ChassisSlots>0 OR RearChassisSlots>0 ORDER BY Label ASC;";
-		}
+		$sql="SELECT * FROM fac_Device WHERE ChassisSlots>0 OR RearChassisSlots>0 ORDER BY Label ASC;";
 
 		$parentList=array();
 		foreach($dbh->query($sql) as $row){
-			// Assigning here will trigger the FilterRights method and check the cabinet rights
-			$temp=Device::RowToObject($row);
-			if($temp->DeviceID==$this->ParentDevice || $temp->Rights=="Write"){
-				$parentList[]=$temp;
+			if($fullinfo){			
+				// Assigning here will trigger the FilterRights method and check the cabinet rights
+				$parentList[]=Device::RowToObject($row);
+			}else{
+				$parentList[]=Device::RowToObject($row,false,false,false);
 			}
 		}
 		

--- a/devices.php
+++ b/devices.php
@@ -785,7 +785,11 @@
 				$pDev->DeviceID=$dev->ParentDevice;
 				$pDev->GetDevice();
 
-				$parentList=$pDev->GetParentDevices();
+				if(isset($_POST['editparent'])){
+					$parentList=$pDev->GetParentDevices();
+				}else{
+					$parentList=$pDev->GetParentDevices($dev->ParentDevice);
+				}
 
 				//$cab->CabinetID=$pDev->Cabinet;
 				//JMGA: changed for multichassis
@@ -1860,6 +1864,10 @@ echo '
 				print "\t\t\t\t<option value=\"$parDev->DeviceID\"$selected data-ChassisSlots=$parDev->ChassisSlots data-RearChassisSlots=$parDev->RearChassisSlots data-CabinetID=$parDev->Cabinet>$parDev->Label</option>\n";
 			}
 			print "\t\t\t</select></div>\n";
+
+			if(!isset($_POST['editparent'])){
+				print "<input type=\"hidden\" name=\"editparent\" value=\"true\"><button type=\"submit\">". __("Fetch"). "</button>\n";
+			}
 		}
 
 echo '		</div>

--- a/devices.php
+++ b/devices.php
@@ -785,11 +785,8 @@
 				$pDev->DeviceID=$dev->ParentDevice;
 				$pDev->GetDevice();
 
-				if(isset($_POST['editparent'])){
-					$parentList=$pDev->GetParentDevices();
-				}else{
-					$parentList=$pDev->GetParentDevices($dev->ParentDevice);
-				}
+				// Get full list of potential ParentDevices
+				$parentList=$pDev->GetParentDevices(false);
 
 				//$cab->CabinetID=$pDev->Cabinet;
 				//JMGA: changed for multichassis
@@ -1864,10 +1861,6 @@ echo '
 				print "\t\t\t\t<option value=\"$parDev->DeviceID\"$selected data-ChassisSlots=$parDev->ChassisSlots data-RearChassisSlots=$parDev->RearChassisSlots data-CabinetID=$parDev->Cabinet>$parDev->Label</option>\n";
 			}
 			print "\t\t\t</select></div>\n";
-
-			if(!isset($_POST['editparent'])){
-				print "<input type=\"hidden\" name=\"editparent\" value=\"true\"><button type=\"submit\">". __("Fetch"). "</button>\n";
-			}
 		}
 
 echo '		</div>


### PR DESCRIPTION
In our environment (close to 10000 Chassis) the GetParentDevices() call is very time-expensive (15 to 30 seconds during which the whole user browser sesssion gets blocked waiting for this call to finish).

Since changing device parent seems to be a rather infrequent operation (I guess .. in our environment it almost never happens ...) proposed PR changes slightly the device edit page: 
- On initial load only current parent device is displayed in the parent list.
- 'Fetch' button is added to the right of the parent list, on click it loads device page again - this time with the full parent list.

Could you please consider this PR for inclusion ?

Thanks

Jarek
