### PR TITLE
Add End of Life Field to Device Templates

### DIFF
--- a/cdu_templates.php
+++ b/cdu_templates.php
@@ -22,6 +22,7 @@
 	if(isset($_REQUEST['action'])&&(($_REQUEST['action']=='Create')||($_REQUEST['action']=='Update'))){
 		$template->ManufacturerID = $_REQUEST['manufacturerid'];
 		$template->Model = transform( $_REQUEST['model'] );
+		$template->EndofLife = isset($_REQUEST['endoflife'])?1:0;
 		$template->Managed = isset($_REQUEST['managed'])?1:0;
 		$template->ATS = isset($_REQUEST['ats'])?1:0;
 		$template->SNMPVersion = $_REQUEST['snmpversion'];
@@ -107,6 +108,10 @@ echo '    </select>
 <div>
    <div><label for="model">',__("Model"),'</label></div>
    <div><input type="text" name="model" id="model" value="',$template->Model,'" size=40></div>
+</div>
+<div>
+   <div><label for="EndofLife">',__("End of Life"),'</label></div>
+   <div><input type="text" class="validate[optional,custom[date]] datepicker" name="EndofLife" id="EndofLife" value="'.(($template->EndofLife>'0000-00-00 00:00:00')?date('Y-m-d',strtotime($template->EndofLife)):"").'"></div>
 </div>
 <div>
    <div><label for="managed">',__("Managed"),'</label></div>

--- a/classes/CDUTemplate.class.php
+++ b/classes/CDUTemplate.class.php
@@ -27,6 +27,7 @@ class CDUTemplate {
 	var $TemplateID;
 	var $ManufacturerID;
 	var $Model;
+	var $EndofLife;
 	var $Managed;
 	var $ATS;
 	var $VersionOID;
@@ -49,6 +50,7 @@ class CDUTemplate {
 		$this->TemplateID=intval($this->TemplateID);
 		$this->ManufacturerID=intval($this->ManufacturerID);
 		$this->Model=sanitize($this->Model);
+		$this->EndofLife=sanitize($this->EndofLife);
 		$this->Managed=intval($this->Managed);
 		$this->ATS=intval($this->ATS);
 		$this->VersionOID=sanitize($this->VersionOID);
@@ -66,6 +68,7 @@ class CDUTemplate {
 
 	function MakeDisplay(){
 		$this->Model=stripslashes($this->Model);
+		$this->EndofLife=stripslashes($this->EndofLife);
 		$this->VersionOID=stripslashes($this->VersionOID);
 		$this->OID1=stripslashes($this->OID1);
 		$this->OID2=stripslashes($this->OID2);
@@ -79,6 +82,7 @@ class CDUTemplate {
 		$template->TemplateID=$row["TemplateID"];
 		$template->ManufacturerID=$row["ManufacturerID"];
 		$template->Model=$row["Model"];
+		$template->EndofLife=$row["EndofLife"];
 		$template->Managed=$row["Managed"];
 		$template->ATS=$row["ATS"];
 		$template->VersionOID=$row["VersionOID"];
@@ -136,7 +140,9 @@ class CDUTemplate {
 		$this->MakeSafe();
 		
 		$sql="INSERT INTO fac_CDUTemplate SET ManufacturerID=$this->ManufacturerID, 
-			Model=\"$this->Model\", Managed=$this->Managed, ATS=$this->ATS,
+			Model=\"$this->Model\",
+			EndofLife=\"".date("Y-m-d",strtotime($this->EndofLife))."\",
+			Managed=$this->Managed, ATS=$this->ATS,
 			VersionOID=\"$this->VersionOID\", 
 			Multiplier=\"$this->Multiplier\", OID1=\"$this->OID1\", OID2=\"$this->OID2\", 
 			OID3=\"$this->OID3\", ATSStatusOID=\"$this->ATSStatusOID\", ATSDesiredResult=\"$this->ATSDesiredResult\",
@@ -162,7 +168,9 @@ class CDUTemplate {
 		$oldtemplate->GetTemplate();
 		
 		$sql="UPDATE fac_CDUTemplate SET ManufacturerID=$this->ManufacturerID, 
-			Model=\"$this->Model\", Managed=$this->Managed, ATS=$this->ATS,
+			Model=\"$this->Model\",
+			EndofLife=\"".date("Y-m-d",strtotime($this->EndofLife))."\",
+			Managed=$this->Managed, ATS=$this->ATS,
 			VersionOID=\"$this->VersionOID\", 
 			Multiplier=\"$this->Multiplier\", OID1=\"$this->OID1\", OID2=\"$this->OID2\", 
 			OID3=\"$this->OID3\", ATSStatusOID=\"$this->ATSStatusOID\", ATSDesiredResult=\"$this->ATSDesiredResult\",

--- a/classes/DeviceTemplate.class.php
+++ b/classes/DeviceTemplate.class.php
@@ -26,6 +26,7 @@ class DeviceTemplate {
 	var $TemplateID;
 	var $ManufacturerID;
 	var $Model;
+	var $EndofLife;
 	var $Height;
 	var $Weight;
 	var $Wattage;
@@ -58,6 +59,7 @@ class DeviceTemplate {
 		$this->TemplateID=intval($this->TemplateID);
 		$this->ManufacturerID=intval($this->ManufacturerID);
 		$this->Model=sanitize($this->Model);
+		$this->EndofLife=sanitize($this->EndofLife);
 		$this->Height=intval($this->Height);
 		$this->Weight=intval($this->Weight);
 		$this->Wattage=intval($this->Wattage);
@@ -75,6 +77,7 @@ class DeviceTemplate {
 
 	function MakeDisplay(){
 		$this->Model=stripslashes($this->Model);
+		$this->EndofLife=stripslashes($this->EndofLife);
         $this->Notes=stripslashes($this->Notes);
         $this->FrontPictureFile=stripslashes($this->FrontPictureFile);
 	    $this->RearPictureFile=stripslashes($this->RearPictureFile);
@@ -85,6 +88,7 @@ class DeviceTemplate {
 		$Template->TemplateID=$row["TemplateID"];
 		$Template->ManufacturerID=$row["ManufacturerID"];
 		$Template->Model=$row["Model"];
+		$Template->EndofLife=$row["EndofLife"];
 		$Template->Height=$row["Height"];
 		$Template->Weight=$row["Weight"];
 		$Template->Wattage=$row["Wattage"];
@@ -144,7 +148,9 @@ class DeviceTemplate {
 		$this->MakeSafe();
 
 		$sql="INSERT INTO fac_DeviceTemplate SET ManufacturerID=$this->ManufacturerID, 
-			Model=\"$this->Model\", Height=$this->Height, Weight=$this->Weight, 
+			Model=\"$this->Model\",
+			EndofLife=\"".date("Y-m-d",strtotime($this->EndofLife))."\",
+			Height=$this->Height, Weight=$this->Weight,
 			Wattage=$this->Wattage, DeviceType=\"$this->DeviceType\", 
 			PSCount=$this->PSCount, NumPorts=$this->NumPorts, Notes=\"$this->Notes\", 
 			FrontPictureFile=\"$this->FrontPictureFile\", RearPictureFile=\"$this->RearPictureFile\",
@@ -187,7 +193,9 @@ class DeviceTemplate {
 	function UpdateTemplate(){
 		$this->MakeSafe();
         $sql="UPDATE fac_DeviceTemplate SET ManufacturerID=$this->ManufacturerID,
-			Model=\"$this->Model\", Height=$this->Height, Weight=$this->Weight, 
+			Model=\"$this->Model\",
+			EndofLife=\"".date("Y-m-d",strtotime($this->EndofLife))."\",
+			Height=$this->Height, Weight=$this->Weight,
 			Wattage=$this->Wattage, DeviceType=\"$this->DeviceType\", 
 			PSCount=$this->PSCount, NumPorts=$this->NumPorts, Notes=\"$this->Notes\", 
 			FrontPictureFile=\"$this->FrontPictureFile\", RearPictureFile=\"$this->RearPictureFile\",
@@ -208,6 +216,7 @@ class DeviceTemplate {
 			// Template changed to CDU from something else, make the extra stuff
 			$cdut=new CDUTemplate();
 			$cdut->Model=$this->Model;
+			$cdut->EndofLife=$this->EndofLife;
 			$cdut->ManufacturerID=$this->ManufacturerID;
 			$cdut->CreateTemplate($this->TemplateID);
 		}
@@ -221,6 +230,7 @@ class DeviceTemplate {
 			// Template changed to Sensor from something else, make the extra stuff
 			$st=new SensorTemplate();
 			$st->Model=$this->Model;
+			$st->EndofLife=$this->EndofLife;
 			$st->ManufacturerID=$this->ManufacturerID;
 			$st->CreateTemplate($this->TemplateID);
 		}
@@ -311,6 +321,7 @@ class DeviceTemplate {
 		//JMGA Reset object in case of a lookup failure
 		$this->ManufacturerID=0;
 		$this->Model="";
+		$this->EndofLife="1970-01-01";
 		$this->Height=0;
 		$this->Weight=0;
 		$this->Wattage=0;

--- a/device_templates.php
+++ b/device_templates.php
@@ -87,6 +87,7 @@
 	if(isset($_POST['action'])){
 		$template->ManufacturerID=$_POST['ManufacturerID'];
 		$template->Model=transform($_POST['Model']);
+		$template->EndofLife=$_POST['EndofLife'];
 		$template->Height=$_POST['Height'];
 		$template->Weight=$_POST['Weight'];
 		$template->Wattage=(isset($_POST['Wattage']))?$_POST['Wattage']:0;
@@ -198,6 +199,7 @@
 			$sensortemplate->TemplateID=$template->TemplateID;
 			$sensortemplate->ManufacturerID=$template->ManufacturerID;
 			$sensortemplate->Model=$template->Model;
+			$sensortemplate->EndofLife=$template->EndofLife;
 			$sensortemplate->TemperatureOID=$_POST['TemperatureOID'];
 			$sensortemplate->HumidityOID=$_POST['HumidityOID'];
 			$sensortemplate->TempMultiplier=$_POST['TempMultiplier'];
@@ -212,6 +214,7 @@
 			$cdutemplate->TemplateID=$template->TemplateID;
 			$cdutemplate->ManufacturerID=$template->ManufacturerID;
 			$cdutemplate->Model=$template->Model;
+			$cdutemplate->EndofLife=$template->EndofLife;
 			$cdutemplate->Managed=isset($_POST['Managed'])?1:0;
 			$cdutemplate->ATS=isset($_POST['ATS'])?1:0;
 			$cdutemplate->VersionOID=$_POST['VersionOID'];
@@ -378,6 +381,7 @@
 				},500);
 			}
 		});
+		$('#EndofLife').datepicker({dateFormat: "yy-mm-dd"});
         
 		$('#clone').click(function(){
 			$('#TemplateID').val(0);
@@ -754,6 +758,10 @@ echo '    </select>
 <div>
    <div><label for="Model">',__("Model"),'</label></div>
    <div><input type="text" name="Model" id="Model" class="validate[required]" value="',$template->Model,'"></div>
+</div>
+<div>
+   <div><label for="EndofLife">',__("End of Life"),'</label></div>
+   <div><input type="text" class="validate[optional,custom[date]] datepicker" name="EndofLife" id="EndofLife" value="'.(($template->EndofLife>'0000-00-00 00:00:00')?date('Y-m-d',strtotime($template->EndofLife)):"").'"></div>
 </div>
 <div>
    <div><label for="Height">',__("Height"),'</label></div>


### PR DESCRIPTION
This is a fairly quick attempt to add a end of life field to the Device Templates.  

Requires:

ALTER TABLE fac_CDUTemplate ADD EndofLife DATE AFTER Model;
ALTER TABLE fac_DeviceTemplate ADD EndofLife DATE AFTER Model;

Definition of End of life is left to the admin - basically what date do you care about most on physical gear - use that one.  

I chose Device Template as opposed to individual devices as it is usually a date for a model not an individual device.  It can be added to a report (or a new report) to show all devices with a EndofLife in the next year, or an aging for capital budgeting decisions.

Any interest in adding it (or a modified version) as an enhancement
