### PR TITLE
Add Return To links on pages

### DIFF
--- a/cabnavigator.php
+++ b/cabnavigator.php
@@ -646,6 +646,22 @@ if($config->ParameterArray["CDUToolTips"]=='enabled'){
 ?>
 </div> <!-- END div#centeriehack -->
 </div></div>
+
+<?php 
+if($cab->ZoneID){
+	$zone=new Zone();
+	$zone->ZoneID=$cab->ZoneID;
+	$zone->GetZone();
+	echo '<a href="zone_stats.php?zone=',$zone->ZoneID,'">[ ',sprintf(__("Return to Zone %s"),$zone->Description),' ]</a><br>';
+}
+if ($cab->CabRowID) {
+	$cabrow=new CabRow();
+	$cabrow->CabRowID=$cab->CabRowID;
+	$cabrow->GetCabRow();
+	echo '<a href="rowview.php?row=',$cabrow->CabRowID,'">[ ',sprintf(__("Return to Row %s"),$cabrow->Name),' ]</a><br>';
+}
+?>
+
 <?php echo '<a href="dc_stats.php?dc=',$dcID,'">[ ',sprintf(__("Return to %s"),$dc->Name),' ]</a>
 <!-- hiding modal dialogs here so they can be translated easily -->
 <div class="hide">

--- a/power_panel.php
+++ b/power_panel.php
@@ -427,7 +427,17 @@ echo '		</select>
 ?>
 </div></div>
 
-<?php echo '<a href="index.php">[ ',__("Return to Main Menu"),' ]</a>
+<?php
+	if ($panel->ParentPanelID) {
+		echo '<a href="power_panel.php?PanelID=', $panel->ParentPanelID, '">[ ',__("Return to Parent Panel"),' ]</a><br>';
+	}
+	foreach($dcList as $dc) {
+		if ($panel->MapDataCenterID and $panel->MapDataCenterID==$dc->DataCenterID) {
+			echo '<a href="dc_stats.php?dc=', $dc->DataCenterID, '">[ ',__("Return to"),' ',$dc->Name.' ]</a><br>'; 
+		}
+	}
+
+echo '<a href="index.php">[ ',__("Return to Main Menu"),' ]</a>
 <!-- hiding modal dialogs here so they can be translated easily -->
 <div class="hide">
 	<div title="',__("Power panel delete confirmation"),'" id="deletemodal">

--- a/rowview.php
+++ b/rowview.php
@@ -167,8 +167,15 @@ $('#centeriehack').width($('#centeriehack div.cabinet').length * 278);
 </script>
 </div></div>
 <?php
+	print "<br>";
+	if($cabrow->ZoneID){ 
+		$zone=new Zone();
+		$zone->ZoneID=$cabrow->ZoneID;
+		$zone->GetZone();
+		print " <a href=\"zone_stats.php?zone=$zone->ZoneID\">[ ".__("Return to Zone")." $zone->Description ]</a>";
+	}
 	if($dcID>0){
-		print "	<br><br><br><a href=\"dc_stats.php?dc=$dcID\">[ ".__("Return to")." $dc->Name ]</a>";
+		print "<br><a href=\"dc_stats.php?dc=$dcID\">[ ".__("Return to")." $dc->Name ]</a>";
 	}
 ?>
 </div>  <!-- END div.main -->

--- a/zone_stats.php
+++ b/zone_stats.php
@@ -323,6 +323,18 @@ echo '
 		</ul>
 	</li>
 </ul>';
+
+print "<br>";
+$cabrow=new CabRow();
+$cabrow->ZoneID=$_GET["zone"];
+$cabrowlist=$cabrow->GetCabRowsByZones();
+foreach($cabrowlist as $cabRow){
+	print " <a href=\"rowview.php?row=$cabRow->CabRowID\">[ ".__("Return to Row")." $cabRow->Name ]</a><br>";
+}
+
+if($dc->DataCenterID>0){
+	print " <a href=\"dc_stats.php?dc=$dc->DataCenterID\">[ ".__("Return to")." $dc->Name ]</a>";
+}
 ?>
 
 </div><!-- END div.main -->


### PR DESCRIPTION
This adds 'Return To' navigation links on bottom of:
- Cabinet Row
- Cabinet
- Zone
- Power Panel
pages. 

I find it useful to be able to navigate down/up hierarchy of assets directly from the page without using left-hand side collapsible hierarchy tree (which also does not include power panels).

