### PR TITLE
Stats tables and kilo-units

### DIFF
--- a/cabnavigator.php
+++ b/cabnavigator.php
@@ -274,7 +274,7 @@ $body.='<div id="infopanel">
 			<td>'.__("Computed Watts").'
 				<div class="meter-wrap">
 					<div class="meter-value" style="background-color: '.$PowerColor.'; width: '.$PowerPercent.'%;">
-						<div class="meter-text">'; $body.=sprintf("%d kW / %d kW",round($totalWatts/1000),$cab->MaxKW);$body.='</div>
+						<div class="meter-text">'; $body.=sprintf("%.2f kW / %d kW",$totalWatts/1000,$cab->MaxKW);$body.='</div>
 					</div>
 				</div>
 			</td>
@@ -283,7 +283,7 @@ $body.='<div id="infopanel">
 			<td>'.__("Measured Watts").'
 				<div class="meter-wrap">
 					<div class="meter-value" style="background-color: '.$MeasuredColor.'; width: '.$MeasuredPercent.'%;">
-						<div class="meter-text">'; $body.=sprintf("%d kW / %d kW",round($measuredWatts/1000),$cab->MaxKW);$body.='</div>
+						<div class="meter-text">'; $body.=sprintf("%.2f kW / %d kW",$measuredWatts/1000,$cab->MaxKW);$body.='</div>
 					</div>
 				</div>
 			</td>

--- a/container_stats.php
+++ b/container_stats.php
@@ -41,10 +41,14 @@ include( "sidebar.inc.php" );
 
 if ( $config->ParameterArray["mUnits"] == "english" ) {
     $vol = __("Square Feet");
+    $volunit = "ft&sup2;";
     $density = __("Watts per Square Foot");
+    $densunit = "W/ft&sup2;";	
 } else {
     $vol = __("Square Meters");
-    $density = __("Watts per Square Meter" );
+    $volunit = "m&sup2;";
+    $density = __("Watts per Square Meter");
+    $densunit = "W/m&sup2;";
 }
 
 echo '<div class="main">
@@ -60,56 +64,56 @@ echo '<div class="main">
 	<div>',__("Available"),'</div>
   </div>
   <div>
-	<div>',sprintf(__("Total U")." %5d",$cStats["TotalU"]),'</div>
-	<div>',sprintf("%3d",$cStats["Infrastructure"]),'</div>
-	<div>',sprintf("%3d",$cStats["Occupied"]),'</div>
-	<div>',sprintf("%3d",$cStats["Allocated"]),'</div>
-	<div>',sprintf("%3d",$cStats["Available"]),'</div>
+	<div>',sprintf(__("Total U")." %s",number_format($cStats["TotalU"])),'</div>
+	<div align="right">',sprintf("%s",number_format($cStats["Infrastructure"])),'</div>
+	<div align="right">',sprintf("%s",number_format($cStats["Occupied"])),'</div>
+	<div align="right">',sprintf("%s",number_format($cStats["Allocated"])),'</div>
+	<div align="right">',sprintf("%s",number_format($cStats["Available"])),'</div>
   </div>
   <div>
 	<div>',__("Percentage"),'</div>
-	<div>',(($cStats["TotalU"])?sprintf("%3.1f%%",$cStats["Infrastructure"]/$cStats["TotalU"]*100):"0"),'</div>
-	<div>',(($cStats["TotalU"])?sprintf("%3.1f%%",$cStats["Occupied"]/$cStats["TotalU"]*100):"0"),'</div>
-	<div>',(($cStats["TotalU"])?sprintf("%3.1f%%",$cStats["Allocated"]/$cStats["TotalU"]*100):"0"),'</div>
-	<div>',(($cStats["TotalU"])?sprintf("%3.1f%%",$cStats["Available"]/$cStats["TotalU"]*100):"0"),'</div>
+	<div align="right">',(($cStats["TotalU"])?sprintf("%3.1f%%",$cStats["Infrastructure"]/$cStats["TotalU"]*100):"0"),'</div>
+	<div align="right">',(($cStats["TotalU"])?sprintf("%3.1f%%",$cStats["Occupied"]/$cStats["TotalU"]*100):"0"),'</div>
+	<div align="right">',(($cStats["TotalU"])?sprintf("%3.1f%%",$cStats["Allocated"]/$cStats["TotalU"]*100):"0"),'</div>
+	<div align="right">',(($cStats["TotalU"])?sprintf("%3.1f%%",$cStats["Available"]/$cStats["TotalU"]*100):"0"),'</div>
   </div>
   </div> <!-- END div.table -->
   <div class="table border">
   <div>
         <div>',__("Data Centers"),'</div>
-        <div>',sprintf("%s ",number_format($cStats["DCs"],0, ",", ".")),'</div>
+        <div>',sprintf("%s ",number_format($cStats["DCs"])),'</div>
   </div>
   <div>
         <div>',__("Computed Wattage"),'</div>
-        <div>',sprintf("%7d %s", $cStats["ComputedWatts"], __("Watts")),'</div>
+        <div>',sprintf("%s",number_format($cStats["ComputedWatts"]/1000)),' kW</div>
   </div>
   <div>
 		<div>',__("Measured Wattage"), '</div>
-		<div>',sprintf("%7d %s", $cStats["MeasuredWatts"], __("Watts")),'</div>
+		<div>',sprintf("%s",number_format($cStats["MeasuredWatts"]/1000)),' kW</div>
   </div>
     <div>
-		<div>',__("Design Maximum (kW)"),'</div>
-		<div>',sprintf("%s kW",number_format($cStats["MaxkW"],0, ",", ".") ),'</div>
+		<div>',__("Design Maximum"),'</div>
+		<div>',sprintf("%s",number_format($cStats["MaxkW"])),' kW</div>
   </div>
   <div>
         <div>',__("BTU Computation from Watts"),'</div>
-        <div>',sprintf("%s ".__("BTU"),number_format($cStats["ComputedWatts"]*3.412,0, ",", ".") ),'</div>
+        <div>',sprintf("%s",number_format($cStats["ComputedWatts"]*3.412/1000)),' kBTU</div>
   </div>
   <div>
         <div>',__("Data Center Size"),'</div>
-        <div>',sprintf("%s ".$vol,number_format($cStats["SquareFootage"],0, ",", ".")),'</div>
+        <div>',sprintf("%s ".$volunit,number_format($cStats["SquareFootage"])),'</div>
   </div>
   <div>
         <div>',$density,'</div>
-        <div>',(($cStats["SquareFootage"]>0)?sprintf("%s ".__("Watts"),number_format($cStats["ComputedWatts"]/$cStats["SquareFootage"],0, ",", ".")):"0 ".__("Watts")),'</div>
+        <div>',(($cStats["SquareFootage"]>0)?sprintf("%s ".$densunit,number_format($cStats["ComputedWatts"]/$cStats["SquareFootage"])):"0 ").'</div>
   </div>
   <div>
         <div>',__("Minimum Cooling Tonnage Required"),'</div>
-        <div>',sprintf("%s ".__("Tons"),number_format($cStats["ComputedWatts"]*3.412*1.15/12000,0, ",", ".")),'</div>
+        <div>',sprintf("%s ".__("Tons"),number_format($cStats["ComputedWatts"]*3.412*1.15/12000)),'</div>
   </div>
   <div>
     <div>',__("Total Cabinets"),'</div>
-    <div>',sprintf( "%s", number_format($cStats["TotalCabinets"],0,",",".")),'</div>
+    <div>',sprintf( "%s", number_format($cStats["TotalCabinets"])),'</div>
   </div>
 </div> <!-- END div.table -->
 </div>

--- a/dc_stats.php
+++ b/dc_stats.php
@@ -144,12 +144,16 @@ $(document).ready(function() {
 		
 	if ( $config->ParameterArray["mUnits"] == "english" ) {
 		$vol = __("Square Feet");
+		$volunit = "ft&sup2;";
 		$tempUnits = "F";
 		$density = __("Watts per Square Foot");
+		$densunit = "W/ft&sup2;";
 	} else {
 		$vol = __("Square Meters");
+		$volunit = "m&sup2;";
 		$tempUnits = "C";
 		$density = __("Watts per Square Meter" );
+		$densunit = "W/m&sup2";
 	}
 	
 ?>
@@ -197,17 +201,17 @@ echo '<div class="main">
   </div>
   <div>
 	<div>',sprintf(__("Total U")." %5d",$dcStats["TotalU"]),'</div>
-	<div>',sprintf("%3d",$dcStats["Infrastructure"]),'</div>
-	<div>',sprintf("%3d",$dcStats["Occupied"]),'</div>
-	<div>',sprintf("%3d",$dcStats["Allocated"]),'</div>
-	<div>',sprintf("%3d",$dcStats["Available"]),'</div>
+	<div align="right">',sprintf("%s",number_format($dcStats["Infrastructure"])),'</div>
+	<div align="right">',sprintf("%s",number_format($dcStats["Occupied"])),'</div>
+	<div align="right">',sprintf("%s",number_format($dcStats["Allocated"])),'</div>
+	<div align="right">',sprintf("%s",number_format($dcStats["Available"])),'</div>
   </div>
   <div>
 	<div>',__("Percentage"),'</div>
-	<div>',(($dcStats["TotalU"])?sprintf("%3.1f%%",$dcStats["Infrastructure"]/$dcStats["TotalU"]*100):"0"),'</div>
-	<div>',(($dcStats["TotalU"])?sprintf("%3.1f%%",$dcStats["Occupied"]/$dcStats["TotalU"]*100):"0"),'</div>
-	<div>',(($dcStats["TotalU"])?sprintf("%3.1f%%",$dcStats["Allocated"]/$dcStats["TotalU"]*100):"0"),'</div>
-	<div>',(($dcStats["TotalU"])?sprintf("%3.1f%%",$dcStats["Available"]/$dcStats["TotalU"]*100):"0"),'</div>
+	<div align="right">',(($dcStats["TotalU"])?sprintf("%s ",number_format($dcStats["Infrastructure"]/$dcStats["TotalU"]*100,1)):"0"),'%</div>
+	<div align="right">',(($dcStats["TotalU"])?sprintf("%s ",number_format($dcStats["Occupied"]/$dcStats["TotalU"]*100,1)):"0"),'%</div>
+	<div align="right">',(($dcStats["TotalU"])?sprintf("%s ",number_format($dcStats["Allocated"]/$dcStats["TotalU"]*100,1)):"0"),'%</div>
+	<div align="right">',(($dcStats["TotalU"])?sprintf("%s ",number_format($dcStats["Available"]/$dcStats["TotalU"]*100,1)):"0"),'%</div>
   </div>
 </div> <!-- END div.table -->
 <div class="table border">
@@ -223,55 +227,55 @@ echo '<div class="main">
 <div class="table border">
   <div>
         <div>',__("Computed Wattage"),'</div>
-        <div>',sprintf("%7d %s", $dcStats["ComputedWatts"], __("Watts")),'</div>
+        <div>',sprintf("%s",number_format($dcStats["ComputedWatts"]/1000)),' kW</div>
   </div>
   <div>
 		<div>',__("Measured Wattage"), '</div>
-		<div>',sprintf("%7d %s", $dcStats["MeasuredWatts"], __("Watts")),'</div>
+		<div>',sprintf("%s",number_format($dcStats["MeasuredWatts"]/1000)),' kW</div>
   </div>
   <div>
-		<div>',__("Design Maximum (kW)"),'</div>
-		<div>',sprintf("%7d kW",$dc->MaxkW ),'</div>
+		<div>',__("Design Maximum"),'</div>
+		<div>',sprintf("%s",number_format($dc->MaxkW)),' kW</div>
   </div>
   <div>
         <div>',__("BTU Computation from Computed Watts"),'</div>
-        <div>',sprintf("%8d ".__("BTU"),$dcStats["ComputedWatts"]*3.412 ),'</div>
+        <div>',sprintf("%s",number_format(($dcStats["ComputedWatts"]*3.412)/1000)),' kBTU</div>
   </div>
   <div>
         <div>',__("Data Center Size"),'</div>
-        <div>',sprintf("%8d %s",$dc->SquareFootage, $vol),'</div>
+        <div>',sprintf("%s %s",number_format($dc->SquareFootage), $volunit),'</div>
   </div>
   <div>
         <div>',$density,'</div>
-        <div>',(($dc->SquareFootage)?sprintf("%8d ".__("Watts"),$dcStats["ComputedWatts"]/$dc->SquareFootage):"0 ".__("Watts")),'</div>
+        <div>',(($dc->SquareFootage)?sprintf("%s",number_format($dcStats["ComputedWatts"]/$dc->SquareFootage)):"0 "),' W</div>
   </div>
   <div>
   	<div>',__("Total Cabinets"),'</div>
-  	<div>',sprintf( "%d", $dcStats["TotalCabinets"] ),'</div>
+  	<div>',sprintf( "%s", number_format($dcStats["TotalCabinets"]) ),'</div>
   </div>
   <div>
         <div>',__("Minimum Cooling Tonnage (Based on Computed Watts)"),'</div>
-        <div>',sprintf("%7d ".__("Tons"),$dcStats["ComputedWatts"]*3.412*1.15/12000),'</div>
+        <div>',sprintf("%s ".__("Tons"), number_format($dcStats["ComputedWatts"]*3.412*1.15/12000)),'</div>
   </div>
   <div>
         <div>',__("Average Temperature"),'</div>
-        <div>',sprintf("%7d %s", $dcStats["AvgTemp"], __("°". $tempUnits)),'</div>
+        <div>',sprintf("%s %s",number_format($dcStats["AvgTemp"]), __("°". $tempUnits)),'</div>
   </div>
   <div>
         <div>',__("Average Humidity"), '</div>
-        <div>',sprintf("%7d %s", $dcStats["AvgHumidity"], __("%")),'</div>
+        <div>',sprintf("%s %s",number_format($dcStats["AvgHumidity"]), __("%")),'</div>
   </div>
   <div>
 		<div>',__("RCI Low Percentage (Overcooling)"), '</div>
-		<div>',(($rciStats["TotalCabinets"])?sprintf("%7d %s",
-					$rciStats["RCILowCount"] / $rciStats["TotalCabinets"] * 100,
+		<div>',(($rciStats["TotalCabinets"])?sprintf("%s %s",
+					number_format($rciStats["RCILowCount"] / $rciStats["TotalCabinets"] * 100),
 		   			__("%")):"0 ".__("%")),
 		'</div>
   </div>
   <div>
 		<div>',__("RCI High Percentage (Cabinets Satisfied)"), '</div>
-		<div>',(($rciStats["TotalCabinets"])?sprintf("%7d %s",
-		   			(1-$rciStats["RCIHighCount"] / $rciStats["TotalCabinets"]) * 100,
+		<div>',(($rciStats["TotalCabinets"])?sprintf("%s %s",
+		   			number_format((1-$rciStats["RCIHighCount"] / $rciStats["TotalCabinets"]) * 100),
 					__("%")):"100 ". __("%")),
 		'</div>
   </div>
@@ -295,7 +299,7 @@ $select="\n\t<select>\n";
 	}
 $select.="\t</select>\n";
 
-echo $select."</div></div>\n".MakeImageMap($dc);
+echo $select."</div></div><br><br>\n<div>".MakeImageMap($dc)."</div>";
 
 echo '
 </div></div>

--- a/index.php
+++ b/index.php
@@ -12,7 +12,7 @@
 
 	$sql = 'select count(*) as DCs from fac_DataCenter';
 	$row=$dbh->query($sql)->fetch();
-	$DCs = $row['DCs'];
+	$DCs = number_format($row['DCs']);
 
 	// Overall Statistics
 	$sql='SELECT SUM(NominalWatts) AS Power,
@@ -26,14 +26,15 @@
 
 	$row=$dbh->query($sql)->fetch();
 
-	$StatsDevices=$row['Devices'];
-	$StatsServers=$row['Servers'];
-	$StatsSize=$row['Size'];
-	$StatsVM=$row['VMcount'];
-	$StatsHost=$row["VMhosts"];
-	$StatsCabinet=$row["CabinetCount"];
-	$StatsPower=$row['Power'];
-	$StatsHeat=$StatsPower * 3.412 / 12000;
+	$StatsDevices=number_format($row['Devices']);
+	$StatsServers=number_format($row['Servers']);
+	$StatsSize=number_format($row['Size']);
+	$StatsVM=number_format($row['VMcount']);
+	$StatsHost=number_format($row["VMhosts"]);
+	$StatsCabinet=number_format($row["CabinetCount"]);
+	$StatsPower=number_format($row['Power'] / 1000);
+	$StatsHeat=number_format($row['Power'] * 3.412 / 12000);
+	$StatsVirtualization=number_format(intval($row['VMcount']/(($row['VMhosts']==0)?1:$row['VMhosts'])));
   
 	$dc = new DataCenter();
 	$dcList = $dc->GetDCList();
@@ -103,45 +104,45 @@ echo '
 </div>';
 echo '
 <div>
-  <div>',__("DC Count"),'</div>
-  <div>',$DCs,'</div>
+  <div>',__("Data Centers"),'</div>
+  <div align="right">',$DCs,'</div>
 </div>';
 echo '
 <div>
   <div>',__("Physical Server Count"),'</div>
-  <div>',$StatsServers,'</div>
+  <div align="right">',$StatsServers,'</div>
 </div>
 <div>
   <div>',__("Other Device Count"),'</div>
-  <div>',$StatsDevices,'</div>
+  <div align="right">',$StatsDevices,'</div>
 </div>
 <div>
   <div>',__("Space"),' (1U=1.75")</div>
-  <div>',$StatsSize,' U</div>
+  <div align="right">',$StatsSize,' U</div>
 </div>
 <div>
   <div>',__("Power Consumption"),'</div>
-  <div>',sprintf("%.2f kW",$StatsPower/1000),'</div>
+  <div align="right">',$StatsPower,' kW</div>
 </div>
 <div>
   <div>',__("Heat Produced"),'</div>
-  <div>',sprintf("%.2f Tons",$StatsHeat),'</div>
+  <div align="right">',$StatsHeat,' Tons</div>
 </div>
 <div>
   <div>',__("Virtual Machines"),'</div>
-  <div>',$StatsVM,'</div>
+  <div align="right">',$StatsVM,'</div>
 </div>
 <div>
-	<div>',__("VM Hosts"),'</div>
-	<div>',$StatsHost,'</div>
+  <div>',__("VM Hosts"),'</div>
+  <div align="right">',$StatsHost,'</div>
 </div>
 <div>
-	<div>',__("Virtualization Ratio"),'</div>
-	<div>',intval($StatsVM/(($StatsHost==0)?1:$StatsHost)),':1</div>
+  <div>',__("Virtualization Ratio"),'</div>
+  <div align="right">',$StatsVirtualization,':1</div>
 </div>
 <div>
-	<div>',__("Total Cabinets"),'</div>
-	<div>',$StatsCabinet,'</div>
+  <div>',__("Total Cabinets"),'</div>
+  <div align="right">',$StatsCabinet,'</div>
 </div>
 </div> <!-- END div.table -->
 	<div>';

--- a/zone_stats.php
+++ b/zone_stats.php
@@ -152,12 +152,16 @@ $(document).ready(function() {
 		
 	if ( $config->ParameterArray["mUnits"] == "english" ) {
 		$vol = __("Square Feet");
+		$volunit = "ft&sup2;";
 		$tempUnits = "F";
 		$density = __("Watts per Square Foot");
+		$densunit = "W/ft&sup2;";
 	} else {
 		$vol = __("Square Meters");
+		$volunit = "m&sup2;";
 		$tempUnits = "C";
 		$density = __("Watts per Square Meter" );
+		$densunit = "W/m&sup2;";
 	}
 	//aproximate proportion between zone/DC 
 	$prop_zone_dc=($zone->MapX2-$zone->MapX1)*($zone->MapY2-$zone->MapY1)/$width/$height;
@@ -207,68 +211,68 @@ echo '<div class="main">
 	<div>',__("Available"),'</div>
   </div>
   <div>
-	<div>',sprintf(__("Total U")." %5d",$zoneStats["TotalU"]),'</div>
-	<div>',sprintf("%3d",$zoneStats["Infrastructure"]),'</div>
-	<div>',sprintf("%3d",$zoneStats["Occupied"]),'</div>
-	<div>',sprintf("%3d",$zoneStats["Allocated"]),'</div>
-	<div>',sprintf("%3d",$zoneStats["Available"]),'</div>
+	<div>',sprintf(__("Total U")." %s",number_format($zoneStats["TotalU"])),'</div>
+	<div align="right">',sprintf("%s",number_format($zoneStats["Infrastructure"])),'</div>
+	<div align="right">',sprintf("%s",number_format($zoneStats["Occupied"])),'</div>
+	<div align="right">',sprintf("%s",number_format($zoneStats["Allocated"])),'</div>
+	<div align="right">',sprintf("%s",number_format($zoneStats["Available"])),'</div>
   </div>
   <div>
 	<div>',__("Percentage"),'</div>
-	<div>',(($zoneStats["TotalU"])?sprintf("%3.1f%%",$zoneStats["Infrastructure"]/$zoneStats["TotalU"]*100):"0"),'</div>
-	<div>',(($zoneStats["TotalU"])?sprintf("%3.1f%%",$zoneStats["Occupied"]/$zoneStats["TotalU"]*100):"0"),'</div>
-	<div>',(($zoneStats["TotalU"])?sprintf("%3.1f%%",$zoneStats["Allocated"]/$zoneStats["TotalU"]*100):"0"),'</div>
-	<div>',(($zoneStats["TotalU"])?sprintf("%3.1f%%",$zoneStats["Available"]/$zoneStats["TotalU"]*100):"0"),'</div>
+	<div align="right">',(($zoneStats["TotalU"])?sprintf("%s",number_format($zoneStats["Infrastructure"]/$zoneStats["TotalU"]*100,1)):"0"),'%</div>
+	<div align="right">',(($zoneStats["TotalU"])?sprintf("%s",number_format($zoneStats["Occupied"]/$zoneStats["TotalU"]*100,1)):"0"),'%</div>
+	<div align="right">',(($zoneStats["TotalU"])?sprintf("%s",number_format($zoneStats["Allocated"]/$zoneStats["TotalU"]*100,1)):"0"),'%</div>
+	<div align="right">',(($zoneStats["TotalU"])?sprintf("%s",number_format($zoneStats["Available"]/$zoneStats["TotalU"]*100,1)):"0"),'%</div>
   </div>
   </div> <!-- END div.table -->
   <div class="table border">
   <div>
         <div>',__("Computed Wattage"),'</div>
-        <div>',sprintf("%7d %s", $zoneStats["ComputedWatts"], __("Watts")),'</div>
+        <div>',sprintf("%s",number_format($zoneStats["ComputedWatts"]/1000)),' kW</div>
   </div>
   <div>
 		<div>',__("Measured Wattage"), '</div>
-		<div>',sprintf("%7d %s", $zoneStats["MeasuredWatts"], __("Watts")),'</div>
+		<div>',sprintf("%s",number_format($zoneStats["MeasuredWatts"]/1000)),' kW</div>
   </div>
   <div>
         <div>',__("BTU Computation from Computed Watts"),'</div>
-        <div>',sprintf("%8d ".__("BTU"),$zoneStats["ComputedWatts"]*3.412 ),'</div>
+        <div>',sprintf("%s", number_format($zoneStats["ComputedWatts"]*3.412/1000)),' kBTU</div>
   </div>
   <div>
         <div>',__("Zone Size (approximate)"),'</div>
-        <div>',sprintf("%8d %s",$dc->SquareFootage*$prop_zone_dc, $vol),'</div>
+        <div>',sprintf("%s %s",number_format($dc->SquareFootage*$prop_zone_dc), $volunit),'</div>
   </div>
   <div>
         <div>',$density,' (',__("approximate"),')</div>
-        <div>',(($dc->SquareFootage)?sprintf("%8d ".__("Watts"),$zoneStats["ComputedWatts"]/$dc->SquareFootage/$prop_zone_dc):"0 ".__("Watts")),'</div>
+        <div>',(($dc->SquareFootage)?sprintf("%s ",number_format($zoneStats["ComputedWatts"]/$dc->SquareFootage/$prop_zone_dc,0)):"0 ").$densunit.'</div>
   </div>
   <div>
   	<div>',__("Total Cabinets"),'</div>
-  	<div>',sprintf("%d", $zoneStats["TotalCabinets"]),'</div>
+  	<div>',sprintf("%s",number_format($zoneStats["TotalCabinets"])),'</div>
   </div>
   <div>
         <div>',__("Minimum Cooling Tonnage (Based on Computed Watts)"),'</div>
-        <div>',sprintf("%7d ".__("Tons"),$zoneStats["ComputedWatts"]*3.412*1.15/12000),'</div>
+        <div>',sprintf("%7s ".__("Tons"),number_format($zoneStats["ComputedWatts"]*3.412*1.15/12000)),'</div>
   </div>
   <div>
         <div>',__("Average Temperature"),'</div>
-        <div>',sprintf("%7d %s", $zoneStats["AvgTemp"], __("°". $tempUnits)),'</div>
+        <div>',sprintf("%s %s", number_format($zoneStats["AvgTemp"]), __("°". $tempUnits)),'</div>
   </div>
   <div>
         <div>',__("Average Humidity"), '</div>
-        <div>',sprintf("%7d %s", $zoneStats["AvgHumidity"], __("%")),'</div>
+        <div>',sprintf("%s %s", number_format($zoneStats["AvgHumidity"]), __("%")),'</div>
   </div>
   <div>
 		<div>',__("RCI Low Percentage (Overcooling)"), '</div>
-		<div>',(($rciStats["TotalCabinets"])?sprintf("%7d %s",
-					$rciStats["RCILowCount"] / $rciStats["TotalCabinets"] * 100,
+		<div>',(($rciStats["TotalCabinets"])?sprintf("%s %s",
+					number_format($rciStats["RCILowCount"] / $rciStats["TotalCabinets"] * 100),
 					__("%")):"0 ".__("%")),
 		'</div>
   </div>
   <div>
 		<div>',__("RCI High Percentage (Cabinets Satisfied)"), '</div>
 		<div>',(($rciStats["TotalCabinets"])?sprintf( "%7d %s",
-					(1-$rciStats["RCIHighCount"] / $rciStats["TotalCabinets"]) * 100,
+					number_format((1-$rciStats["RCIHighCount"] / $rciStats["TotalCabinets"]) * 100),
 					__("%")):"100 ".__("%")),'</div>
   </div>
 </div> <!-- END div.table -->
@@ -291,7 +295,7 @@ $select='<select>';
 	}
 $select.='</select>';
 
-echo $select.'</div></div>'.MakeImageMap($dc,$zone);
+echo $select.'</div></div><br><br><div>'.MakeImageMap($dc,$zone).'</div>';
 
 echo '
 </div></div>


### PR DESCRIPTION
This PR proposes to align formatting global/dc/zone/row stats tables with minor display/layout changes:

- right-alignement of values,
- using 'number_format' function in all places,
- using kilo-Units (kW kBTU ..) in statistics,

plus one minor change in dispay for cabnavigator:

- 2 decimal places for Computed an Measured Watts 

(Please note that I am really unsure if it should be sqft or ft2 (and W/sqft  or W/ft2) ... or other abbreviation ... )


