### PR TITLE
UI: disable draggable cabinet content if no rights

### DIFF
--- a/cabnavigator.php
+++ b/cabnavigator.php
@@ -670,6 +670,13 @@ if($config->ParameterArray["CDUToolTips"]=='enabled'){
 </div>'; ?>
 </div>  <!-- END div.main -->
 
+<?php
+if($person->CanWrite($cab->AssignedTo) || $person->SiteAdmin) {
+    echo '<div><input type="hidden" name="cabinetdraggable" id="cabinetdraggable" value="yes"></div>';
+}
+?>
+
+
 <div class="clear"></div>
 </div>
 <script type="text/javascript">

--- a/rowview.php
+++ b/rowview.php
@@ -175,7 +175,7 @@ $('#centeriehack').width($('#centeriehack div.cabinet').length * 278);
 ?>
 </div>  <!-- END div.main -->
 <?php
-	if ($person->SiteAdmin || $person->RackAdmin) {
+	if ($person->SiteAdmin || $person->RackAdmin || $person->WriteAccess) {
                 print '<div><input type="hidden" name="cabinetdraggable" id="cabinetdraggable" value="yes"></div>';
         }
 ?>

--- a/rowview.php
+++ b/rowview.php
@@ -113,11 +113,13 @@ echo $head,'  <script type="text/javascript" src="scripts/jquery.min.js"></scrip
   <script type="text/javascript" src="scripts/common.js?v',filemtime('scripts/common.js'),'"></script>
   <script type="text/javascript">
 	$(document).ready(function() {
-		$(".cabinet .error").append("*");
-		$("<button>",{type: "button"}).text("'.__("Add new cabinet").'").click(function(){
+		$(".cabinet .error").append("*");';
+if ($person->RackAdmin || $person->SiteAdmin) {
+		echo '$("<button>",{type: "button"}).text("'.__("Add new cabinet").'").click(function(){
 			document.location.href="cabinets.php?dcid=',$dcID,'&zoneid=',$cabrow->ZoneID,'&cabrowid=',$cabrow->CabRowID,'";
-		}).prependTo($(".main"));
-		$("<button>",{id: "reverse", type: "button"}).text("'.(isset($_GET["rear"])?__("Front View"):__("Rear View")).'").click(function(){
+		}).prependTo($(".main"));';
+}
+		echo '$("<button>",{id: "reverse", type: "button"}).text("'.(isset($_GET["rear"])?__("Front View"):__("Rear View")).'").click(function(){
 			document.location.href="rowview.php?row=',$cabrow->CabRowID.(isset($_GET["rear"])?"":"&rear"),'";
 		}).prependTo($(".main"));';
 
@@ -172,6 +174,11 @@ $('#centeriehack').width($('#centeriehack div.cabinet').length * 278);
 	}
 ?>
 </div>  <!-- END div.main -->
+<?php
+	if ($person->SiteAdmin || $person->RackAdmin) {
+                print '<div><input type="hidden" name="cabinetdraggable" id="cabinetdraggable" value="yes"></div>';
+        }
+?>
 
 <div class="clear"></div>
 </div>

--- a/scripts/common.js
+++ b/scripts/common.js
@@ -1450,6 +1450,8 @@ function intersectRect(r1, r2) {
 
 // function to make server objects draggable in the UI
 function initdrag(){
+   var isdraggable = document.getElementById('cabinetdraggable').value;
+   if (isdraggable == 'yes') {
 	$('.draggable').draggable({
 		helper: 'clone',
 		grid: [ 220, 1 ],
@@ -1637,6 +1639,7 @@ function initdrag(){
 			$('#tt').remove();
 		}
 	});
+   } // if isdraggable
 }
 
 function InsertDevice(obj){


### PR DESCRIPTION
This PR proposes to hide/remove 'Add new cabinet' button in Row view as well as disable possibility to drag racked items for users without privileges.