### PR TITLE
search_export... reports move controls to left

### DIFF
--- a/search_export.php
+++ b/search_export.php
@@ -243,7 +243,10 @@
   <link rel="stylesheet" href="css/print.css" type="text/css" media="print">
   <link rel="stylesheet" href="css/jquery-ui.css" type="text/css">
   <link rel="stylesheet" href="css/jquery.dataTables.min.css" type="text/css">
-  <style type="text/css"></style>
+  <style type="text/css">
+    div.dt-buttons { float: left; }
+    #export_filter { float: left; margin-left: 25px; }
+  </style>
   <!--[if lt IE 9]>
   <link rel="stylesheet"  href="css/ie.css" type="text/css" />
   <![endif]-->

--- a/search_export_storage_room.php
+++ b/search_export_storage_room.php
@@ -174,7 +174,10 @@
   <link rel="stylesheet" href="css/print.css" type="text/css" media="print">
   <link rel="stylesheet" href="css/jquery-ui.css" type="text/css">
   <link rel="stylesheet" href="css/jquery.dataTables.min.css" type="text/css">
-  <style type="text/css"></style>
+  <style type="text/css">
+    div.dt-buttons { float: left; }
+    #export_filter { float: left; margin-left: 25px; }
+  </style>
   <!--[if lt IE 9]>
   <link rel="stylesheet"  href="css/ie.css" type="text/css" />
   <![endif]-->


### PR DESCRIPTION
The controls on the right are often off the screen to the right.  Making this the default seems to make the most sense instead of making it configurable.

If you think there is a need for this option to be configurable let me know.