### PR TITLE
Display a Goto Panel link in the Power Specs pane

### DIFF
--- a/devices.php
+++ b/devices.php
@@ -2152,7 +2152,9 @@ echo '
 		echo '
 				</select>
 			</div>'
-		print "<div><a href=\"power_panel.php?PanelID=$pdu->PanelID\">[ ".__("Goto Panel")." ]</a></div>\n";
+		if($pdu->PanelID >0){
+			print "<div><a href=\"power_panel.php?PanelID=$pdu->PanelID\">[ ".__("Goto Panel")." ]</a></div>\n";
+		}	
 		echo '
 		</div>
 		<div>

--- a/devices.php
+++ b/devices.php
@@ -2151,7 +2151,9 @@ echo '
 
 		echo '
 				</select>
-			</div>
+			</div>'
+		print "<div><a href=\"power_panel.php?PanelID=$pdu->PanelID\">[ ".__("Goto Panel")." ]</a></div>\n";
+		echo '
 		</div>
 		<div>
 			<div><label for="voltage">',__("Voltages:"),'</label></div>

--- a/devices.php
+++ b/devices.php
@@ -2151,7 +2151,7 @@ echo '
 
 		echo '
 				</select>
-			</div>'
+			</div>';
 		if($pdu->PanelID >0){
 			print "<div><a href=\"power_panel.php?PanelID=$pdu->PanelID\">[ ".__("Goto Panel")." ]</a></div>\n";
 		}	


### PR DESCRIPTION
I found that this functionality was useful: maybe someone else might.

It wasn't clear to me whether this link should/could be a "Return to Source Panel" link
appearing down with the "Return to Navigator" link at the bottom of the page, but I went
with placing it inside the Power Specifications pane as you are already in a region of 
the code that has $pdu and $pnl defined.

FWIW, I have often thought that a similar link to the Device Class from the Physical
Infrastructure  pane might be useful too.

Anyroad, yours to do with, as you see fit.