### PR TITLE
Fix incorrect column name in bulk_container.php count query

### DIFF
--- a/bulk_container.php
+++ b/bulk_container.php
@@ -223,7 +223,7 @@
       
       // Rows are also optional
       if ( $row["Row"] != "" && $DataCenterID > 0 ) {
-        $st = $dbh->prepare( "select count(RowID) as TotalMatches, CabRowID from fac_CabRow where DataCenterID=:DataCenterID and ZoneID=:ZoneID and ucase(Name)=ucase(:Name)" );
+        $st = $dbh->prepare( "select count(CabRowID) as TotalMatches, CabRowID from fac_CabRow where DataCenterID=:DataCenterID and ZoneID=:ZoneID and ucase(Name)=ucase(:Name)" );
         $st->execute( array( ":DataCenterID"=>$DataCenterID, ":ZoneID"=>$ZoneID, ":Name"=>$row["Row"] ));
         if ( ! $val = $st->fetch() ) {
           $info = $dbh->errorInfo();


### PR DESCRIPTION
## Summary
- Fixed `count(RowID)` to `count(CabRowID)` in the SQL query at line 226 of `bulk_container.php`
- The `RowID` column does not exist in `fac_CabRow` table; the correct primary key column is `CabRowID`
- This was causing a 500 error when performing bulk container imports

Fixes #1519