### PR TITLE
Fix custom device status colors not showing in row view

### DIFF
--- a/rowview.php
+++ b/rowview.php
@@ -33,7 +33,7 @@
 	foreach($dsList as $stat){
 		if($stat->ColorCode != "#FFFFFF"){
 			$stName=str_replace(' ','_',$stat->Status);
-			$important=($stName == 'Reserved')?' !important':'';
+			$important=' !important';
 
 			$head.="\t\t\t.$stName {background-color: {$stat->ColorCode}$important;}\n";
 		}


### PR DESCRIPTION
## Summary
- Applied `!important` to all custom device status color CSS rules in `rowview.php`, not just the `Reserved` status
- Previously, department colors (generated later in the stylesheet) would override custom status colors due to CSS cascade order
- The `Reserved` status was the only one working because it was the only one with `!important`
- This also allows any custom status (e.g. Disposed, Out-of-Production) to override owner color on the row view

Fixes #1165
Fixes #1582