### PR TITLE
Increase fac_Config.Value column size for upgraded installations

### DIFF
--- a/db-23.04-to-25.01.sql
+++ b/db-23.04-to-25.01.sql
@@ -111,4 +111,10 @@ ALTER TABLE fac_TemplatePowerPorts ADD COLUMN ConnectorID int(11) DEFAULT NULL A
 ALTER TABLE fac_TemplatePowerPorts ADD COLUMN PhaseID int(11) DEFAULT NULL AFTER ConnectorID;
 ALTER TABLE fac_TemplatePowerPorts ADD COLUMN VoltageID int(11) DEFAULT NULL AFTER PhaseID;
 
+--
+-- Increase fac_Config.Value column size for upgraded installations
+-- New installs already have TEXT type from create.sql
+--
+ALTER TABLE fac_Config MODIFY Value text NOT NULL;
+
 UPDATE fac_Config set Value="25.01" WHERE Parameter="Version";


### PR DESCRIPTION
## Summary
- Added `ALTER TABLE fac_Config MODIFY Value text NOT NULL` to the 23.04-to-25.01 migration script
- New installations already have `TEXT` type from `create.sql`, but installations upgraded from older versions still have `VARCHAR(200)` which is too short for long LDAP base search paths
- This ensures upgraded installations get the same column type as new installs

Fixes #1104