### PR TITLE
Enable Select All checkbox in cabinet report

### DIFF
--- a/report_cabinets.php
+++ b/report_cabinets.php
@@ -106,8 +106,7 @@
         <div><?php print __("Cabinet ID")?></div>
     </div>
 <?php
-    // because mpdf is so slow, selecting all cabinets in a big data center frequently times out - just disabling fo rnow
-    //print "<div><div><input type=\"checkbox\" id=\"selectall\">".__("Select all")."</input></div></div>\n";
+    print "<div><div><input type=\"checkbox\" id=\"selectall\"> ".__("Select all")."</div></div>\n";
         foreach ( $cabList as $cab ) {
             print "<div><div><input type=\"checkbox\" class=\"selectedId\" id=\"selectedId\" name=\"cabinetid[]\" value=\"$cab->CabinetID\">$cab->Location</input></div></div>\n";
         }


### PR DESCRIPTION
## Summary
- Re-enabled the "Select All" checkbox in the cabinet report page
- The checkbox and its JavaScript handler were already implemented but commented out due to mPDF performance concerns
- Users with many cabinets can now easily select/deselect all cabinets for reporting

Fixes #1156