### PR TITLE
Fix 500 error when mapping columns to None in network bulk upload

### DIFF
--- a/bulk_network.php
+++ b/bulk_network.php
@@ -155,8 +155,12 @@
 
       // Load up the $row[] array with the values according to the mapping supplied by the user
       foreach( $fields as $fname ) {
-        $addr = chr( 64 + $_REQUEST[$fname]);
-        $row[$fname] = sanitize($sheet->getCell( $addr . $n )->getValue());
+        if ( $_REQUEST[$fname] == 0 ) {
+          $row[$fname] = "";
+        } else {
+          $addr = chr( 64 + $_REQUEST[$fname]);
+          $row[$fname] = sanitize($sheet->getCell( $addr . $n )->getValue());
+        }
       }
 
       switch( $_REQUEST["KeyField"] ) {


### PR DESCRIPTION
## Summary
- Fixed crash when optional columns (MediaType, ColorCode, Notes) are mapped to "None" in the network bulk upload
- When mapped to "None" (value 0), `chr(64 + 0)` produced `@` which is an invalid cell coordinate for PhpSpreadsheet
- Fields mapped to "None" now correctly default to an empty string

Fixes #1040