### PR TITLE
Fix broken device links in SVG network map report

### DIFF
--- a/report_network_map.php
+++ b/report_network_map.php
@@ -9,7 +9,7 @@
     if(isset($_REQUEST['format'])) {
         # find the directory that dcim is being hosted out of (used when we build
         # the url for each node
-        $baseURI = $config->ParameterArray["InstallURL"];
+        $baseURI = rtrim($config->ParameterArray["InstallURL"], '/') . '/';
         # way to randomize the colors/styles
         # 0 == randomize colors if color can't be identified from db
         # 1 == Randomize colors, keeping same color for each colorid


### PR DESCRIPTION
## Summary
- Normalized `InstallURL` with a trailing slash when building device URLs in the SVG network map
- When `InstallURL` was configured without a trailing slash (e.g. `https://example.com`), generated links were malformed: `https://example.comdevices.php?DeviceID=123` instead of `https://example.com/devices.php?DeviceID=123`
- Uses `rtrim($url, '/') . '/'` to handle both cases safely

Fixes #1568