### PR TITLE
Fix Add Link OK button not working in device notes editor

### DIFF
--- a/scripts/jquery-te-1.4.0.js
+++ b/scripts/jquery-te-1.4.0.js
@@ -582,6 +582,7 @@
 							replaceSelection("a",setdatalink,"");
 						}
 					}else{
+						replaceSelection("a",setdatalink,"");
 						linkinput.val(thisHrefLink).focus();
 					}
 					


### PR DESCRIPTION
## Summary
- Fixed the "Add Link" OK button doing nothing when entering a web address in device notes
- The jQuery TE editor's `selected2link` function was not calling `replaceSelection` when no text was pre-selected, so no element received the `setdatalink` marker attribute
- The OK button handler (`linkRecord`) searches for elements with that attribute and found nothing, causing the silent failure
- Added the missing `replaceSelection` call in the else branch

Fixes #1431