### PR TITLE
Convert supply status report from mPDF to Excel

### DIFF
--- a/report_supply_status.php
+++ b/report_supply_status.php
@@ -5,118 +5,91 @@
 
 	require_once( "db.inc.php" );
 	require_once( "facilities.inc.php" );
-	
+
 	if(!$person->ReadAccess){
 	    // No soup for you.
 	    header('Location: '.redirect());
 	    exit;
 	}
 
-	/* Version 1.0 of this report has no selectable parameters - you just get a complete dump */
-	
-	$mpdf=new \Mpdf\Mpdf(['tempDir'=>sys_get_temp_dir(),'mode'=>'s']);
-	$mpdf->SetAuthor($config->ParameterArray["OrgName"]);
-	$mpdf->SetDisplayMode('fullpage');
-	$mpdf->useActiveForms = true;
-	$mpdf->SetTitle($config->ParameterArray["OrgName"] . " " . __("Supply Status Report"));
+	/* Version 2.0 of this report uses PhpSpreadsheet instead of mPDF */
+
+	$xl = new \PhpOffice\PhpSpreadsheet\Spreadsheet();
+
+	$xl->getProperties()->setCreator($config->ParameterArray["OrgName"]);
+	$xl->getProperties()->setLastModifiedBy("openDCIM");
+	$xl->getProperties()->setTitle($config->ParameterArray["OrgName"] . " " . __("Supply Status Report"));
+	$xl->getProperties()->setSubject(__("Supply Status Report"));
+
+	$xl->setActiveSheetIndex(0);
+	$currSheet = $xl->getActiveSheet();
+	$currSheet->setTitle(__("Supply Status"));
+
+	// Header row
+	$currSheet->setCellValue('A1', __("Part Number"));
+	$currSheet->setCellValue('B1', __("Part Name"));
+	$currSheet->setCellValue('C1', __("Min Qty"));
+	$currSheet->setCellValue('D1', __("Max Qty"));
+	$currSheet->setCellValue('E1', __("On Hand"));
+	$currSheet->setCellValue('F1', __("Location"));
+	$currSheet->setCellValue('G1', __("Location Count"));
+
+	// Bold header row
+	$currSheet->getStyle('A1:G1')->getFont()->setBold(true);
+	$currSheet->getStyle('A1:G1')->getFill()
+		->setFillType(\PhpOffice\PhpSpreadsheet\Style\Fill::FILL_SOLID)
+		->getStartColor()->setRGB('EEEEEE');
 
 	$sup = new Supplies();
 	$bin = new SupplyBin();
 	$bc = new BinContents();
-	
+
 	$SupplyList = $sup->GetSuppliesList();
-	
-	$html = '
-<html>
-<head>
-<style>
-body {font-family: sans-serif;
-    font-size: 10pt;
-}
-p {    margin: 0pt;
-}
-td { vertical-align: top; }
-.items td {
-    border-left: 0.1mm solid #000000;
-    border-right: 0.1mm solid #000000;
-}
-table thead td { background-color: #EEEEEE;
-    text-align: center;
-    border: 0.1mm solid #000000;
-}
-.items td.bottom {
-    background-color: #FFFFFF;
-    border: 0mm none #000000;
-    border-top: 0.1mm solid #000000;
-}
-.items td.totals {
-    text-align: right;
-    border: 0.1mm solid #000000;
-}
-</style>
-</head>
-<body>
 
-<!--mpdf
-<htmlpageheader name="myheader">
-<table width="100%"><tr>
-<td width="50%" style="color:#0000BB;"><span style="font-weight: bold; font-size: 14pt;">'.$config->ParameterArray["OrgName"].'</span></td>
-<td width="50%" style="text-align: right;">'.__("Date").':<span style="font-weight: bold; font-size: 12pt;">'.strftime("%x").'</span></td>
-</tr></table>
-</htmlpageheader>
-
-<htmlpagefooter name="myfooter">
-<div style="border-top: 1px solid #000000; font-size: 9pt; text-align: center; padding-top: 3mm; ">
-Page {PAGENO} of {nb}
-</div>
-</htmlpagefooter>
-
-<sethtmlpageheader name="myheader" value="on" show-this-page="1" />
-<sethtmlpagefooter name="myfooter" value="on" />
-mpdf-->
-
-<h2>'.__("Supplies Status Report").'
-<table class="items" width="100%" style="font-size: 9pt; border-collapse: collapse;" cellpadding="8">
-<thead>
-<tr>
-<td width="20%">'.__("Part Number").'</td>
-<td width="50%">'.__("Part Name").'</td>
-<td width="10%">'.__("Min Qty").'</td>
-<td width="10%">'.__("Max Qty").'</td>
-<td width="10%">'.__("On Hand").'</td>
-</tr>
-</thead>
-<tbody>
-<!-- ITEMS HERE -->';
+	$row = 2;
 
 	foreach ( $SupplyList as $Supply ) {
-		$html .= sprintf('<tr><td align="center">%s</td><td>%s</td><td align="right">%d</td><td align="right">%d</td><td align="right">%d</td></tr>\n', 
-			$Supply->PartNum, $Supply->PartName, $Supply->MinQty, $Supply->MaxQty, Supplies::GetSupplyCount($Supply->SupplyID) );
-			
+		$onHand = Supplies::GetSupplyCount($Supply->SupplyID);
+
+		$currSheet->setCellValue("A{$row}", $Supply->PartNum);
+		$currSheet->setCellValue("B{$row}", $Supply->PartName);
+		$currSheet->setCellValue("C{$row}", $Supply->MinQty);
+		$currSheet->setCellValue("D{$row}", $Supply->MaxQty);
+		$currSheet->setCellValue("E{$row}", $onHand);
+
+		// Highlight row if on hand is below minimum
+		if ($onHand < $Supply->MinQty) {
+			$currSheet->getStyle("A{$row}:G{$row}")->getFill()
+				->setFillType(\PhpOffice\PhpSpreadsheet\Style\Fill::FILL_SOLID)
+				->getStartColor()->setRGB('F28A8C');
+		}
+
 		$bc->SupplyID = $Supply->SupplyID;
 		$binList = $bc->FindSupplies();
-		
+
 		foreach ( $binList as $sb ) {
 			$bin->BinID = $sb->BinID;
 			$bin->GetBin();
-			
-			$html .= sprintf( '<tr><td>&nbsp;</td><td>%s: %s</td><td>&nbsp;</td><td>&nbsp;</td><td align="right">%d</td></tr>\n', __("Location"), $bin->Location, $sb->Count );
+
+			$currSheet->setCellValue("F{$row}", $bin->Location);
+			$currSheet->setCellValue("G{$row}", $sb->Count);
+			$row++;
+		}
+
+		if (empty($binList)) {
+			$row++;
 		}
 	}
-	
-	$html .= '<!-- END ITEMS HERE -->
-<tr>
-<td class="bottom" colspan=5>&nbsp;</td>
-</tbody>
-</table>
-</body>
-</html>
-';
 
-$mpdf->WriteHTML($html);
+	foreach( range( 'A', 'G' ) as $col ) {
+		$currSheet->getColumnDimension($col)->setAutoSize( true );
+	}
+	$currSheet->calculateColumnWidths();
 
-$mpdf->Output(); exit;
+	header('Content-Type: application/vnd.openxmlformats-officedocument.spreadsheetml.sheet');
+	header( sprintf( "Content-Disposition: attachment;filename=\"opendcim-supply-status-%s.xlsx\"", date( "YmdHis" ) ) );
 
-exit;
-
+	$writer = new \PhpOffice\PhpSpreadsheet\Writer\Xlsx($xl);
+	$writer->save('php://output');
+	exit;
 ?>


### PR DESCRIPTION
## Summary
- Replaced the broken mPDF-based supply status report with PhpSpreadsheet (Excel output)
- The report was throwing "Class mPDF not found" because the mPDF library is no longer available
- Uses PhpSpreadsheet which is already a project dependency used by other reports
- Added red highlighting for supplies that are below their minimum quantity threshold
- Added Location and Location Count columns for per-bin breakdown

Fixes #1375