### PR TITLE
Fix Update button not creating pending new device statuses

### DIFF
--- a/configuration.php
+++ b/configuration.php
@@ -1896,6 +1896,8 @@
 				$('#messages').text('');
 				// Don't let this button do a real form submit
 				e.preventDefault();
+				// If there is a pending new status in the input, create it before saving
+				$('#devstatus .newstatus img').trigger('click');
 				// Collect the config data
 				var formdata=$(".main form").serializeArray();
 				// Set the action of the form to Update


### PR DESCRIPTION
## Summary

When a user types a new device status name in the blank input field on the Configuration page and clicks the **Update** button (instead of pressing Enter or clicking the + icon), the new status was silently lost.

This fix triggers the add-status action on the pending input before collecting the form data for the Update submission, ensuring no typed status is lost.

Fixes #1041